### PR TITLE
feat: swap player sprites on hustle style selection 

### DIFF
--- a/Journey To The West/Assets/Editor.meta
+++ b/Journey To The West/Assets/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a64ee3ce24d07604e87bfdd8a1516344
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Journey To The West/Assets/Editor/HustleStyleSpriteSetup.cs
+++ b/Journey To The West/Assets/Editor/HustleStyleSpriteSetup.cs
@@ -1,0 +1,73 @@
+using UnityEditor;
+using UnityEngine;
+using System.Linq;
+
+public static class HustleStyleSpriteSetup
+{
+    private static readonly (string styleName, string characterFolder)[] StyleMap =
+    {
+        ("Default", "Jin"),
+        ("Brute", "Brute"),
+        ("Scammer", "Scammer"),
+        ("Haggler", "Haggler")
+    };
+
+    [MenuItem("Tools/Setup Hustle Style Sprites")]
+    public static void SetupAllStyles()
+    {
+        int successCount = 0;
+
+        foreach (var (styleName, folder) in StyleMap)
+        {
+            string assetPath = $"Assets/Resources/HustleStyles/{styleName}.asset";
+            var style = AssetDatabase.LoadAssetAtPath<HustleStyleData>(assetPath);
+            if (style == null)
+            {
+                Debug.LogWarning($"[SpriteSetup] Could not find HustleStyleData at {assetPath}");
+                continue;
+            }
+
+            string basePath = $"Assets/Sprites/{folder}/SeparateAnim";
+
+            style.idleSprites = LoadSortedSprites($"{basePath}/Idle.png");
+            style.walkSprites = LoadSortedSprites($"{basePath}/Walk.png");
+            style.attackSprites = LoadSortedSprites($"{basePath}/Attack.png");
+
+            EditorUtility.SetDirty(style);
+            successCount++;
+
+            Debug.Log($"[SpriteSetup] {styleName} ({folder}): " +
+                      $"{style.idleSprites.Length} idle, " +
+                      $"{style.walkSprites.Length} walk, " +
+                      $"{style.attackSprites.Length} attack sprites");
+        }
+
+        AssetDatabase.SaveAssets();
+        Debug.Log($"[SpriteSetup] Done! Set up {successCount}/{StyleMap.Length} styles. Check Console for details.");
+    }
+
+    private static Sprite[] LoadSortedSprites(string assetPath)
+    {
+        var allAssets = AssetDatabase.LoadAllAssetsAtPath(assetPath);
+        if (allAssets == null || allAssets.Length == 0)
+        {
+            Debug.LogWarning($"[SpriteSetup] No assets found at {assetPath}. Is the sprite sheet sliced?");
+            return new Sprite[0];
+        }
+
+        return allAssets
+            .OfType<Sprite>()
+            .OrderBy(s => GetSpriteIndex(s.name))
+            .ToArray();
+    }
+
+    private static int GetSpriteIndex(string name)
+    {
+        int lastUnderscore = name.LastIndexOf('_');
+        if (lastUnderscore >= 0 && int.TryParse(name.Substring(lastUnderscore + 1), out int index))
+        {
+            return index;
+        }
+        return 0;
+    }
+}

--- a/Journey To The West/Assets/Editor/HustleStyleSpriteSetup.cs.meta
+++ b/Journey To The West/Assets/Editor/HustleStyleSpriteSetup.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e8df61eeebfffac44aeed007bef0e20b

--- a/Journey To The West/Assets/Resources/HustleStyles/Brute.asset
+++ b/Journey To The West/Assets/Resources/HustleStyles/Brute.asset
@@ -15,6 +15,33 @@ MonoBehaviour:
   styleName: Brute
   description: Wins more from combat, but intimidation makes merchants less generous.
   sprite: {fileID: 21300000, guid: 6beeda12d5d07cd40a61a1d9744e87dd, type: 3}
+  idleSprites:
+  - {fileID: 4723107735738678597, guid: b76663a5396a259498383e60c0233605, type: 3}
+  - {fileID: -7385789195546760866, guid: b76663a5396a259498383e60c0233605, type: 3}
+  - {fileID: 3234629978573100161, guid: b76663a5396a259498383e60c0233605, type: 3}
+  - {fileID: -1162165200, guid: b76663a5396a259498383e60c0233605, type: 3}
+  walkSprites:
+  - {fileID: 4035959289877228764, guid: d21774a7003395f449e61beae876e2d7, type: 3}
+  - {fileID: -982904232830982447, guid: d21774a7003395f449e61beae876e2d7, type: 3}
+  - {fileID: -350908408369970039, guid: d21774a7003395f449e61beae876e2d7, type: 3}
+  - {fileID: -5409570386352685021, guid: d21774a7003395f449e61beae876e2d7, type: 3}
+  - {fileID: 1553940418269799609, guid: d21774a7003395f449e61beae876e2d7, type: 3}
+  - {fileID: 2416434504916517810, guid: d21774a7003395f449e61beae876e2d7, type: 3}
+  - {fileID: -6428935122508569504, guid: d21774a7003395f449e61beae876e2d7, type: 3}
+  - {fileID: 7144598999076838305, guid: d21774a7003395f449e61beae876e2d7, type: 3}
+  - {fileID: 7500509103958437945, guid: d21774a7003395f449e61beae876e2d7, type: 3}
+  - {fileID: 1008816216748069464, guid: d21774a7003395f449e61beae876e2d7, type: 3}
+  - {fileID: -2069663781, guid: d21774a7003395f449e61beae876e2d7, type: 3}
+  - {fileID: -498298363, guid: d21774a7003395f449e61beae876e2d7, type: 3}
+  - {fileID: 2013800134, guid: d21774a7003395f449e61beae876e2d7, type: 3}
+  - {fileID: -1503714531, guid: d21774a7003395f449e61beae876e2d7, type: 3}
+  - {fileID: 1451851780, guid: d21774a7003395f449e61beae876e2d7, type: 3}
+  - {fileID: -1026608898, guid: d21774a7003395f449e61beae876e2d7, type: 3}
+  attackSprites:
+  - {fileID: -7008412969330441016, guid: 81113f28c1a710c4bad26c9a36747659, type: 3}
+  - {fileID: -7763475090823894447, guid: 81113f28c1a710c4bad26c9a36747659, type: 3}
+  - {fileID: 2085922585, guid: 81113f28c1a710c4bad26c9a36747659, type: 3}
+  - {fileID: 559521974, guid: 81113f28c1a710c4bad26c9a36747659, type: 3}
   combatGoldModifier: 1.3
   npcGoldModifier: 1
   shopPriceModifier: 1.2

--- a/Journey To The West/Assets/Resources/HustleStyles/Default.asset
+++ b/Journey To The West/Assets/Resources/HustleStyles/Default.asset
@@ -15,6 +15,33 @@ MonoBehaviour:
   styleName: Default
   description: Neutral baseline hustle style with no modifiers.
   sprite: {fileID: 7322885499304307244, guid: 81f701f654f34524fb6e71d6e8a37e37, type: 3}
+  idleSprites:
+  - {fileID: 4723107735738678597, guid: 24d67b8d650dad64a958cdf424dbd088, type: 3}
+  - {fileID: -7385789195546760866, guid: 24d67b8d650dad64a958cdf424dbd088, type: 3}
+  - {fileID: 3234629978573100161, guid: 24d67b8d650dad64a958cdf424dbd088, type: 3}
+  - {fileID: -1930971669, guid: 24d67b8d650dad64a958cdf424dbd088, type: 3}
+  walkSprites:
+  - {fileID: 4035959289877228764, guid: b3d3fc37aa5931f4393505ff7d4c1cc2, type: 3}
+  - {fileID: -982904232830982447, guid: b3d3fc37aa5931f4393505ff7d4c1cc2, type: 3}
+  - {fileID: -350908408369970039, guid: b3d3fc37aa5931f4393505ff7d4c1cc2, type: 3}
+  - {fileID: -5409570386352685021, guid: b3d3fc37aa5931f4393505ff7d4c1cc2, type: 3}
+  - {fileID: 1553940418269799609, guid: b3d3fc37aa5931f4393505ff7d4c1cc2, type: 3}
+  - {fileID: 2416434504916517810, guid: b3d3fc37aa5931f4393505ff7d4c1cc2, type: 3}
+  - {fileID: -6428935122508569504, guid: b3d3fc37aa5931f4393505ff7d4c1cc2, type: 3}
+  - {fileID: 7144598999076838305, guid: b3d3fc37aa5931f4393505ff7d4c1cc2, type: 3}
+  - {fileID: 7500509103958437945, guid: b3d3fc37aa5931f4393505ff7d4c1cc2, type: 3}
+  - {fileID: 1008816216748069464, guid: b3d3fc37aa5931f4393505ff7d4c1cc2, type: 3}
+  - {fileID: 745740535, guid: b3d3fc37aa5931f4393505ff7d4c1cc2, type: 3}
+  - {fileID: -304983608, guid: b3d3fc37aa5931f4393505ff7d4c1cc2, type: 3}
+  - {fileID: -1189268668, guid: b3d3fc37aa5931f4393505ff7d4c1cc2, type: 3}
+  - {fileID: -1138804702, guid: b3d3fc37aa5931f4393505ff7d4c1cc2, type: 3}
+  - {fileID: -773112772, guid: b3d3fc37aa5931f4393505ff7d4c1cc2, type: 3}
+  - {fileID: -2045649278, guid: b3d3fc37aa5931f4393505ff7d4c1cc2, type: 3}
+  attackSprites:
+  - {fileID: -7008412969330441016, guid: f2abc46f60567264fa6ee1ce7298652b, type: 3}
+  - {fileID: -7763475090823894447, guid: f2abc46f60567264fa6ee1ce7298652b, type: 3}
+  - {fileID: 302641331129538988, guid: f2abc46f60567264fa6ee1ce7298652b, type: 3}
+  - {fileID: -71067674, guid: f2abc46f60567264fa6ee1ce7298652b, type: 3}
   combatGoldModifier: 1
   npcGoldModifier: 1
   shopPriceModifier: 1

--- a/Journey To The West/Assets/Resources/HustleStyles/Haggler.asset
+++ b/Journey To The West/Assets/Resources/HustleStyles/Haggler.asset
@@ -15,6 +15,33 @@ MonoBehaviour:
   styleName: Haggler
   description: Cuts deals, pockets a quick windfall, and trades toughness for thrift.
   sprite: {fileID: 21300000, guid: 4fb4b38974dc3da49ad1262d96444191, type: 3}
+  idleSprites:
+  - {fileID: 4723107735738678597, guid: a95690c106c03d14d9b523de9bd59dd8, type: 3}
+  - {fileID: -7385789195546760866, guid: a95690c106c03d14d9b523de9bd59dd8, type: 3}
+  - {fileID: 3234629978573100161, guid: a95690c106c03d14d9b523de9bd59dd8, type: 3}
+  - {fileID: 679286945, guid: a95690c106c03d14d9b523de9bd59dd8, type: 3}
+  walkSprites:
+  - {fileID: 4035959289877228764, guid: 8eb397a4b8077d44f80a7120a3350442, type: 3}
+  - {fileID: -982904232830982447, guid: 8eb397a4b8077d44f80a7120a3350442, type: 3}
+  - {fileID: -350908408369970039, guid: 8eb397a4b8077d44f80a7120a3350442, type: 3}
+  - {fileID: -5409570386352685021, guid: 8eb397a4b8077d44f80a7120a3350442, type: 3}
+  - {fileID: 1553940418269799609, guid: 8eb397a4b8077d44f80a7120a3350442, type: 3}
+  - {fileID: 2416434504916517810, guid: 8eb397a4b8077d44f80a7120a3350442, type: 3}
+  - {fileID: -6428935122508569504, guid: 8eb397a4b8077d44f80a7120a3350442, type: 3}
+  - {fileID: 7144598999076838305, guid: 8eb397a4b8077d44f80a7120a3350442, type: 3}
+  - {fileID: 7500509103958437945, guid: 8eb397a4b8077d44f80a7120a3350442, type: 3}
+  - {fileID: 695513350, guid: 8eb397a4b8077d44f80a7120a3350442, type: 3}
+  - {fileID: 1648081557, guid: 8eb397a4b8077d44f80a7120a3350442, type: 3}
+  - {fileID: -1782430362, guid: 8eb397a4b8077d44f80a7120a3350442, type: 3}
+  - {fileID: 563291288, guid: 8eb397a4b8077d44f80a7120a3350442, type: 3}
+  - {fileID: 1336053237, guid: 8eb397a4b8077d44f80a7120a3350442, type: 3}
+  - {fileID: 999112247, guid: 8eb397a4b8077d44f80a7120a3350442, type: 3}
+  - {fileID: -745718810, guid: 8eb397a4b8077d44f80a7120a3350442, type: 3}
+  attackSprites:
+  - {fileID: -7008412969330441016, guid: af5bbb8d8669d684996a6a78b153348c, type: 3}
+  - {fileID: -7763475090823894447, guid: af5bbb8d8669d684996a6a78b153348c, type: 3}
+  - {fileID: 302641331129538988, guid: af5bbb8d8669d684996a6a78b153348c, type: 3}
+  - {fileID: -1920499266, guid: af5bbb8d8669d684996a6a78b153348c, type: 3}
   combatGoldModifier: 1
   npcGoldModifier: 1
   shopPriceModifier: 0.75

--- a/Journey To The West/Assets/Resources/HustleStyles/Scammer.asset
+++ b/Journey To The West/Assets/Resources/HustleStyles/Scammer.asset
@@ -15,6 +15,33 @@ MonoBehaviour:
   styleName: Scammer
   description: Talks circles around NPCs to squeeze out better payouts.
   sprite: {fileID: 21300000, guid: 14bf0293ba235dc4d82f4eed5919264c, type: 3}
+  idleSprites:
+  - {fileID: 4723107735738678597, guid: 17226c1c847ead5479e087e5857d8c8c, type: 3}
+  - {fileID: -1451311899, guid: 17226c1c847ead5479e087e5857d8c8c, type: 3}
+  - {fileID: 1249232488, guid: 17226c1c847ead5479e087e5857d8c8c, type: 3}
+  - {fileID: 652850686, guid: 17226c1c847ead5479e087e5857d8c8c, type: 3}
+  walkSprites:
+  - {fileID: 4035959289877228764, guid: 7ad033d85e268a84b94459cc65641e5e, type: 3}
+  - {fileID: -982904232830982447, guid: 7ad033d85e268a84b94459cc65641e5e, type: 3}
+  - {fileID: -350908408369970039, guid: 7ad033d85e268a84b94459cc65641e5e, type: 3}
+  - {fileID: -5409570386352685021, guid: 7ad033d85e268a84b94459cc65641e5e, type: 3}
+  - {fileID: -1070111882, guid: 7ad033d85e268a84b94459cc65641e5e, type: 3}
+  - {fileID: -258869128, guid: 7ad033d85e268a84b94459cc65641e5e, type: 3}
+  - {fileID: 1395707758, guid: 7ad033d85e268a84b94459cc65641e5e, type: 3}
+  - {fileID: 967042945, guid: 7ad033d85e268a84b94459cc65641e5e, type: 3}
+  - {fileID: -191942432, guid: 7ad033d85e268a84b94459cc65641e5e, type: 3}
+  - {fileID: -1151903921, guid: 7ad033d85e268a84b94459cc65641e5e, type: 3}
+  - {fileID: -531119815, guid: 7ad033d85e268a84b94459cc65641e5e, type: 3}
+  - {fileID: 1833484480, guid: 7ad033d85e268a84b94459cc65641e5e, type: 3}
+  - {fileID: 1609967264, guid: 7ad033d85e268a84b94459cc65641e5e, type: 3}
+  - {fileID: 944902872, guid: 7ad033d85e268a84b94459cc65641e5e, type: 3}
+  - {fileID: 1768821728, guid: 7ad033d85e268a84b94459cc65641e5e, type: 3}
+  - {fileID: 635422702, guid: 7ad033d85e268a84b94459cc65641e5e, type: 3}
+  attackSprites:
+  - {fileID: -7008412969330441016, guid: d7917a1e754c61d428849050a6f44503, type: 3}
+  - {fileID: -861807607, guid: d7917a1e754c61d428849050a6f44503, type: 3}
+  - {fileID: 666022993, guid: d7917a1e754c61d428849050a6f44503, type: 3}
+  - {fileID: 1294306720, guid: d7917a1e754c61d428849050a6f44503, type: 3}
   combatGoldModifier: 0.8
   npcGoldModifier: 1.2
   shopPriceModifier: 1

--- a/Journey To The West/Assets/Scripts/Player/CharacterSpriteSwapper.cs
+++ b/Journey To The West/Assets/Scripts/Player/CharacterSpriteSwapper.cs
@@ -1,0 +1,54 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+public class CharacterSpriteSwapper : MonoBehaviour
+{
+    private SpriteRenderer spriteRenderer;
+    private Dictionary<Sprite, Sprite> swapMap;
+
+    private void Awake()
+    {
+        spriteRenderer = GetComponent<SpriteRenderer>();
+    }
+
+    public void BuildSwapMap(HustleStyleData fromStyle, HustleStyleData toStyle)
+    {
+        if (fromStyle == null || toStyle == null || fromStyle == toStyle)
+        {
+            swapMap = null;
+            return;
+        }
+
+        swapMap = new Dictionary<Sprite, Sprite>();
+        AddMappings(fromStyle.idleSprites, toStyle.idleSprites);
+        AddMappings(fromStyle.walkSprites, toStyle.walkSprites);
+        AddMappings(fromStyle.attackSprites, toStyle.attackSprites);
+    }
+
+    public void ClearSwapMap()
+    {
+        swapMap = null;
+    }
+
+    private void AddMappings(Sprite[] from, Sprite[] to)
+    {
+        if (from == null || to == null) return;
+        int count = Mathf.Min(from.Length, to.Length);
+        for (int i = 0; i < count; i++)
+        {
+            if (from[i] != null && to[i] != null)
+            {
+                swapMap[from[i]] = to[i];
+            }
+        }
+    }
+
+    private void LateUpdate()
+    {
+        if (swapMap == null || spriteRenderer == null) return;
+        if (swapMap.TryGetValue(spriteRenderer.sprite, out Sprite replacement))
+        {
+            spriteRenderer.sprite = replacement;
+        }
+    }
+}

--- a/Journey To The West/Assets/Scripts/Player/CharacterSpriteSwapper.cs.meta
+++ b/Journey To The West/Assets/Scripts/Player/CharacterSpriteSwapper.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 371123f8d9d798047a3e6f01e16aac02

--- a/Journey To The West/Assets/Scripts/Player/HustleStyleData.cs
+++ b/Journey To The West/Assets/Scripts/Player/HustleStyleData.cs
@@ -6,6 +6,12 @@ public class HustleStyleData : ScriptableObject
     public string styleName;
     [TextArea] public string description;
     public Sprite sprite;
+
+    [Header("Character Sprites (auto-populated by Tools > Setup Hustle Style Sprites)")]
+    public Sprite[] idleSprites;
+    public Sprite[] walkSprites;
+    public Sprite[] attackSprites;
+
     public float combatGoldModifier = 1f;
     public float npcGoldModifier = 1f;
     public float shopPriceModifier = 1f;

--- a/Journey To The West/Assets/Scripts/Player/HustleStyleManager.cs
+++ b/Journey To The West/Assets/Scripts/Player/HustleStyleManager.cs
@@ -147,5 +147,12 @@ public class HustleStyleManager : MonoBehaviour
         {
             playerCombat.ApplyMaxHPModifier(style.maxHPModifier);
         }
+
+        CharacterSpriteSwapper swapper = player.GetComponent<CharacterSpriteSwapper>();
+        if (swapper == null)
+        {
+            swapper = player.AddComponent<CharacterSpriteSwapper>();
+        }
+        swapper.BuildSwapMap(defaultStyle, style);
     }
 }

--- a/Journey To The West/Assets/Sprites/Brute/SeparateAnim/Attack.png.meta
+++ b/Journey To The West/Assets/Sprites/Brute/SeparateAnim/Attack.png.meta
@@ -40,7 +40,7 @@ TextureImporter:
   maxTextureSize: 2048
   textureSettings:
     serializedVersion: 2
-    filterMode: 1
+    filterMode: 0
     aniso: 1
     mipBias: 0
     wrapU: 1
@@ -54,7 +54,7 @@ TextureImporter:
   spriteMeshType: 1
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
-  spritePixelsToUnits: 100
+  spritePixelsToUnits: 16
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
@@ -78,7 +78,7 @@ TextureImporter:
     maxTextureSize: 2048
     resizeAlgorithm: 0
     textureFormat: -1
-    textureCompression: 1
+    textureCompression: 2
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0
@@ -108,10 +108,10 @@ TextureImporter:
         serializedVersion: 2
         x: 0
         y: 0
-        width: 48
+        width: 16
         height: 16
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -128,12 +128,12 @@ TextureImporter:
       name: Attack_1
       rect:
         serializedVersion: 2
-        x: 48
+        x: 16
         y: 0
         width: 16
-        height: 15
+        height: 16
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -146,11 +146,55 @@ TextureImporter:
       indices: 
       edges: []
       weights: []
+    - serializedVersion: 2
+      name: Attack_2
+      rect:
+        serializedVersion: 2
+        x: 32
+        y: 0
+        width: 16
+        height: 16
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: c27f7bacd9b43c949b3e6de3d1235b81
+      internalID: 2085922585
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Attack_3
+      rect:
+        serializedVersion: 2
+        x: 48
+        y: 0
+        width: 16
+        height: 16
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 92fde0eae7812ec4aae395c173163bcf
+      internalID: 559521974
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
     outline: []
     customData: 
     physicsShape: []
     bones: []
-    spriteID: 
+    spriteID: 54584be729216044ea3b78167f1c9383
     internalID: 0
     vertices: []
     indices: 
@@ -158,10 +202,14 @@ TextureImporter:
     weights: []
     secondaryTextures: []
     spriteCustomMetadata:
-      entries: []
+      entries:
+      - key: SpriteEditor.SliceSettings
+        value: '{"sliceOnImport":false,"gridCellCount":{"x":1.0,"y":1.0},"gridSpriteSize":{"x":16.0,"y":16.0},"gridSpriteOffset":{"x":0.0,"y":0.0},"gridSpritePadding":{"x":0.0,"y":0.0},"pivot":{"x":0.5,"y":0.5},"pivotPixels":{"x":0.0,"y":0.0},"autoSlicingMethod":0,"spriteAlignment":0,"pivotUnitMode":0,"slicingType":1,"keepEmptyRects":false,"isAlternate":false}'
     nameFileIdTable:
       Attack_0: -7008412969330441016
       Attack_1: -7763475090823894447
+      Attack_2: 2085922585
+      Attack_3: 559521974
   mipmapLimitGroupName: 
   pSDRemoveMatte: 0
   userData: 

--- a/Journey To The West/Assets/Sprites/Brute/SeparateAnim/Idle.png.meta
+++ b/Journey To The West/Assets/Sprites/Brute/SeparateAnim/Idle.png.meta
@@ -43,7 +43,7 @@ TextureImporter:
   maxTextureSize: 2048
   textureSettings:
     serializedVersion: 2
-    filterMode: 1
+    filterMode: 0
     aniso: 1
     mipBias: 0
     wrapU: 1
@@ -57,7 +57,7 @@ TextureImporter:
   spriteMeshType: 1
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
-  spritePixelsToUnits: 100
+  spritePixelsToUnits: 16
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
@@ -81,7 +81,7 @@ TextureImporter:
     maxTextureSize: 2048
     resizeAlgorithm: 0
     textureFormat: -1
-    textureCompression: 1
+    textureCompression: 2
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0
@@ -111,10 +111,10 @@ TextureImporter:
         serializedVersion: 2
         x: 0
         y: 0
-        width: 33
+        width: 16
         height: 16
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -131,12 +131,12 @@ TextureImporter:
       name: Idle_1
       rect:
         serializedVersion: 2
-        x: 32
+        x: 16
         y: 0
         width: 16
         height: 16
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -153,12 +153,12 @@ TextureImporter:
       name: Idle_2
       rect:
         serializedVersion: 2
-        x: 48
+        x: 32
         y: 0
         width: 16
         height: 16
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -171,11 +171,33 @@ TextureImporter:
       indices: 
       edges: []
       weights: []
+    - serializedVersion: 2
+      name: Idle_3
+      rect:
+        serializedVersion: 2
+        x: 48
+        y: 0
+        width: 16
+        height: 16
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: ebcaceb14054d2f41a15ece2f6f28c0e
+      internalID: -1162165200
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
     outline: []
     customData: 
     physicsShape: []
     bones: []
-    spriteID: 
+    spriteID: 9e8c1b06883b30044945430c0b14c27b
     internalID: 0
     vertices: []
     indices: 
@@ -183,11 +205,14 @@ TextureImporter:
     weights: []
     secondaryTextures: []
     spriteCustomMetadata:
-      entries: []
+      entries:
+      - key: SpriteEditor.SliceSettings
+        value: '{"sliceOnImport":false,"gridCellCount":{"x":1.0,"y":1.0},"gridSpriteSize":{"x":16.0,"y":16.0},"gridSpriteOffset":{"x":0.0,"y":0.0},"gridSpritePadding":{"x":0.0,"y":0.0},"pivot":{"x":0.5,"y":0.5},"pivotPixels":{"x":0.0,"y":0.0},"autoSlicingMethod":0,"spriteAlignment":0,"pivotUnitMode":0,"slicingType":1,"keepEmptyRects":false,"isAlternate":false}'
     nameFileIdTable:
       Idle_0: 4723107735738678597
       Idle_1: -7385789195546760866
       Idle_2: 3234629978573100161
+      Idle_3: -1162165200
   mipmapLimitGroupName: 
   pSDRemoveMatte: 0
   userData: 

--- a/Journey To The West/Assets/Sprites/Brute/SeparateAnim/Walk.png.meta
+++ b/Journey To The West/Assets/Sprites/Brute/SeparateAnim/Walk.png.meta
@@ -64,7 +64,7 @@ TextureImporter:
   maxTextureSize: 2048
   textureSettings:
     serializedVersion: 2
-    filterMode: 1
+    filterMode: 0
     aniso: 1
     mipBias: 0
     wrapU: 1
@@ -78,7 +78,7 @@ TextureImporter:
   spriteMeshType: 1
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
-  spritePixelsToUnits: 100
+  spritePixelsToUnits: 16
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
@@ -102,7 +102,7 @@ TextureImporter:
     maxTextureSize: 2048
     resizeAlgorithm: 0
     textureFormat: -1
-    textureCompression: 1
+    textureCompression: 2
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0
@@ -131,11 +131,11 @@ TextureImporter:
       rect:
         serializedVersion: 2
         x: 0
-        y: 31
-        width: 33
-        height: 33
+        y: 48
+        width: 16
+        height: 16
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -152,12 +152,12 @@ TextureImporter:
       name: Walk_1
       rect:
         serializedVersion: 2
-        x: 32
-        y: 47
+        x: 16
+        y: 48
         width: 16
-        height: 17
+        height: 16
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -175,11 +175,11 @@ TextureImporter:
       rect:
         serializedVersion: 2
         x: 32
-        y: 31
+        y: 48
         width: 16
         height: 16
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -197,11 +197,11 @@ TextureImporter:
       rect:
         serializedVersion: 2
         x: 48
-        y: 47
+        y: 48
         width: 16
-        height: 17
+        height: 16
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -218,12 +218,12 @@ TextureImporter:
       name: Walk_4
       rect:
         serializedVersion: 2
-        x: 48
-        y: 31
+        x: 0
+        y: 32
         width: 16
         height: 16
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -240,12 +240,12 @@ TextureImporter:
       name: Walk_5
       rect:
         serializedVersion: 2
-        x: 0
-        y: 0
-        width: 33
-        height: 32
+        x: 16
+        y: 32
+        width: 16
+        height: 16
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -263,11 +263,11 @@ TextureImporter:
       rect:
         serializedVersion: 2
         x: 32
-        y: 15
+        y: 32
         width: 16
-        height: 17
+        height: 16
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -284,12 +284,12 @@ TextureImporter:
       name: Walk_7
       rect:
         serializedVersion: 2
-        x: 32
-        y: 0
+        x: 48
+        y: 32
         width: 16
-        height: 15
+        height: 16
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -306,12 +306,12 @@ TextureImporter:
       name: Walk_8
       rect:
         serializedVersion: 2
-        x: 48
-        y: 15
+        x: 0
+        y: 16
         width: 16
-        height: 17
+        height: 16
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -328,12 +328,12 @@ TextureImporter:
       name: Walk_9
       rect:
         serializedVersion: 2
-        x: 48
-        y: 0
+        x: 16
+        y: 16
         width: 16
-        height: 15
+        height: 16
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -346,11 +346,143 @@ TextureImporter:
       indices: 
       edges: []
       weights: []
+    - serializedVersion: 2
+      name: Walk_10
+      rect:
+        serializedVersion: 2
+        x: 32
+        y: 16
+        width: 16
+        height: 16
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 87d8bbad414abce4ab6506aa53611e63
+      internalID: -2069663781
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Walk_11
+      rect:
+        serializedVersion: 2
+        x: 48
+        y: 16
+        width: 16
+        height: 16
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: f2fcbf2dc6a0a9d43a6c13595e28a36b
+      internalID: -498298363
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Walk_12
+      rect:
+        serializedVersion: 2
+        x: 0
+        y: 0
+        width: 16
+        height: 16
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: f83eba73c523a8641a8c0faac4f9c82d
+      internalID: 2013800134
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Walk_13
+      rect:
+        serializedVersion: 2
+        x: 16
+        y: 0
+        width: 16
+        height: 16
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 76be868e32a10e241bace30f8ed40f85
+      internalID: -1503714531
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Walk_14
+      rect:
+        serializedVersion: 2
+        x: 32
+        y: 0
+        width: 16
+        height: 16
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: f149472a765704a48877236c872b931d
+      internalID: 1451851780
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Walk_15
+      rect:
+        serializedVersion: 2
+        x: 48
+        y: 0
+        width: 16
+        height: 16
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 3b8022e3b3736d042b59989b84a20491
+      internalID: -1026608898
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
     outline: []
     customData: 
     physicsShape: []
     bones: []
-    spriteID: 
+    spriteID: 01d4b029c01373142a8e8667eef3c7a1
     internalID: 0
     vertices: []
     indices: 
@@ -358,10 +490,18 @@ TextureImporter:
     weights: []
     secondaryTextures: []
     spriteCustomMetadata:
-      entries: []
+      entries:
+      - key: SpriteEditor.SliceSettings
+        value: '{"sliceOnImport":false,"gridCellCount":{"x":1.0,"y":1.0},"gridSpriteSize":{"x":16.0,"y":16.0},"gridSpriteOffset":{"x":0.0,"y":0.0},"gridSpritePadding":{"x":0.0,"y":0.0},"pivot":{"x":0.5,"y":0.5},"pivotPixels":{"x":0.0,"y":0.0},"autoSlicingMethod":0,"spriteAlignment":0,"pivotUnitMode":0,"slicingType":1,"keepEmptyRects":false,"isAlternate":false}'
     nameFileIdTable:
       Walk_0: 4035959289877228764
       Walk_1: -982904232830982447
+      Walk_10: -2069663781
+      Walk_11: -498298363
+      Walk_12: 2013800134
+      Walk_13: -1503714531
+      Walk_14: 1451851780
+      Walk_15: -1026608898
       Walk_2: -350908408369970039
       Walk_3: -5409570386352685021
       Walk_4: 1553940418269799609

--- a/Journey To The West/Assets/Sprites/Haggler/SeparateAnim/Attack.png.meta
+++ b/Journey To The West/Assets/Sprites/Haggler/SeparateAnim/Attack.png.meta
@@ -43,7 +43,7 @@ TextureImporter:
   maxTextureSize: 2048
   textureSettings:
     serializedVersion: 2
-    filterMode: 1
+    filterMode: 0
     aniso: 1
     mipBias: 0
     wrapU: 1
@@ -57,7 +57,7 @@ TextureImporter:
   spriteMeshType: 1
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
-  spritePixelsToUnits: 100
+  spritePixelsToUnits: 16
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
@@ -81,7 +81,7 @@ TextureImporter:
     maxTextureSize: 2048
     resizeAlgorithm: 0
     textureFormat: -1
-    textureCompression: 1
+    textureCompression: 2
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0
@@ -111,10 +111,10 @@ TextureImporter:
         serializedVersion: 2
         x: 0
         y: 0
-        width: 17
+        width: 16
         height: 16
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -136,7 +136,7 @@ TextureImporter:
         width: 16
         height: 16
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -155,10 +155,10 @@ TextureImporter:
         serializedVersion: 2
         x: 32
         y: 0
-        width: 32
+        width: 16
         height: 16
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -171,11 +171,33 @@ TextureImporter:
       indices: 
       edges: []
       weights: []
+    - serializedVersion: 2
+      name: Attack_3
+      rect:
+        serializedVersion: 2
+        x: 48
+        y: 0
+        width: 16
+        height: 16
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 974cd55c59e1d0347bafd9bc52c49d1e
+      internalID: -1920499266
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
     outline: []
     customData: 
     physicsShape: []
     bones: []
-    spriteID: 
+    spriteID: 03759e42e04234c4e8bcc2eaf682e24c
     internalID: 0
     vertices: []
     indices: 
@@ -183,11 +205,14 @@ TextureImporter:
     weights: []
     secondaryTextures: []
     spriteCustomMetadata:
-      entries: []
+      entries:
+      - key: SpriteEditor.SliceSettings
+        value: '{"sliceOnImport":false,"gridCellCount":{"x":1.0,"y":1.0},"gridSpriteSize":{"x":16.0,"y":16.0},"gridSpriteOffset":{"x":0.0,"y":0.0},"gridSpritePadding":{"x":0.0,"y":0.0},"pivot":{"x":0.5,"y":0.5},"pivotPixels":{"x":0.0,"y":0.0},"autoSlicingMethod":0,"spriteAlignment":0,"pivotUnitMode":0,"slicingType":1,"keepEmptyRects":false,"isAlternate":false}'
     nameFileIdTable:
       Attack_0: -7008412969330441016
       Attack_1: -7763475090823894447
       Attack_2: 302641331129538988
+      Attack_3: -1920499266
   mipmapLimitGroupName: 
   pSDRemoveMatte: 0
   userData: 

--- a/Journey To The West/Assets/Sprites/Haggler/SeparateAnim/Idle.png.meta
+++ b/Journey To The West/Assets/Sprites/Haggler/SeparateAnim/Idle.png.meta
@@ -43,7 +43,7 @@ TextureImporter:
   maxTextureSize: 2048
   textureSettings:
     serializedVersion: 2
-    filterMode: 1
+    filterMode: 0
     aniso: 1
     mipBias: 0
     wrapU: 1
@@ -57,7 +57,7 @@ TextureImporter:
   spriteMeshType: 1
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
-  spritePixelsToUnits: 100
+  spritePixelsToUnits: 16
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
@@ -81,7 +81,7 @@ TextureImporter:
     maxTextureSize: 2048
     resizeAlgorithm: 0
     textureFormat: -1
-    textureCompression: 1
+    textureCompression: 2
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0
@@ -114,7 +114,7 @@ TextureImporter:
         width: 16
         height: 16
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -134,9 +134,9 @@ TextureImporter:
         x: 16
         y: 0
         width: 16
-        height: 15
+        height: 16
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -155,10 +155,10 @@ TextureImporter:
         serializedVersion: 2
         x: 32
         y: 0
-        width: 32
+        width: 16
         height: 16
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -171,11 +171,33 @@ TextureImporter:
       indices: 
       edges: []
       weights: []
+    - serializedVersion: 2
+      name: Idle_3
+      rect:
+        serializedVersion: 2
+        x: 48
+        y: 0
+        width: 16
+        height: 16
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 7c4c85da58a5aaa48b45dd5b78400771
+      internalID: 679286945
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
     outline: []
     customData: 
     physicsShape: []
     bones: []
-    spriteID: 
+    spriteID: f682d5d7c7b2e0546a31dfe00c490561
     internalID: 0
     vertices: []
     indices: 
@@ -183,11 +205,14 @@ TextureImporter:
     weights: []
     secondaryTextures: []
     spriteCustomMetadata:
-      entries: []
+      entries:
+      - key: SpriteEditor.SliceSettings
+        value: '{"sliceOnImport":false,"gridCellCount":{"x":1.0,"y":1.0},"gridSpriteSize":{"x":16.0,"y":16.0},"gridSpriteOffset":{"x":0.0,"y":0.0},"gridSpritePadding":{"x":0.0,"y":0.0},"pivot":{"x":0.5,"y":0.5},"pivotPixels":{"x":0.0,"y":0.0},"autoSlicingMethod":0,"spriteAlignment":0,"pivotUnitMode":0,"slicingType":1,"keepEmptyRects":false,"isAlternate":false}'
     nameFileIdTable:
       Idle_0: 4723107735738678597
       Idle_1: -7385789195546760866
       Idle_2: 3234629978573100161
+      Idle_3: 679286945
   mipmapLimitGroupName: 
   pSDRemoveMatte: 0
   userData: 

--- a/Journey To The West/Assets/Sprites/Haggler/SeparateAnim/Walk.png.meta
+++ b/Journey To The West/Assets/Sprites/Haggler/SeparateAnim/Walk.png.meta
@@ -61,7 +61,7 @@ TextureImporter:
   maxTextureSize: 2048
   textureSettings:
     serializedVersion: 2
-    filterMode: 1
+    filterMode: 0
     aniso: 1
     mipBias: 0
     wrapU: 1
@@ -75,7 +75,7 @@ TextureImporter:
   spriteMeshType: 1
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
-  spritePixelsToUnits: 100
+  spritePixelsToUnits: 16
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
@@ -99,7 +99,7 @@ TextureImporter:
     maxTextureSize: 2048
     resizeAlgorithm: 0
     textureFormat: -1
-    textureCompression: 1
+    textureCompression: 2
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0
@@ -128,11 +128,11 @@ TextureImporter:
       rect:
         serializedVersion: 2
         x: 0
-        y: 0
-        width: 17
-        height: 64
+        y: 48
+        width: 16
+        height: 16
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -150,11 +150,11 @@ TextureImporter:
       rect:
         serializedVersion: 2
         x: 16
-        y: 47
+        y: 48
         width: 16
         height: 16
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -171,12 +171,12 @@ TextureImporter:
       name: Walk_2
       rect:
         serializedVersion: 2
-        x: 16
-        y: 31
+        x: 32
+        y: 48
         width: 16
-        height: 17
+        height: 16
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -193,12 +193,12 @@ TextureImporter:
       name: Walk_3
       rect:
         serializedVersion: 2
-        x: 31
-        y: 31
-        width: 33
-        height: 17
+        x: 48
+        y: 48
+        width: 16
+        height: 16
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -215,12 +215,12 @@ TextureImporter:
       name: Walk_4
       rect:
         serializedVersion: 2
-        x: 32
-        y: 47
-        width: 32
-        height: 17
+        x: 0
+        y: 32
+        width: 16
+        height: 16
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -238,11 +238,11 @@ TextureImporter:
       rect:
         serializedVersion: 2
         x: 16
-        y: 15
+        y: 32
         width: 16
         height: 16
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -259,12 +259,12 @@ TextureImporter:
       name: Walk_6
       rect:
         serializedVersion: 2
-        x: 16
-        y: 0
+        x: 32
+        y: 32
         width: 16
         height: 16
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -281,12 +281,12 @@ TextureImporter:
       name: Walk_7
       rect:
         serializedVersion: 2
-        x: 31
-        y: 0
-        width: 33
+        x: 48
+        y: 32
+        width: 16
         height: 16
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -303,12 +303,12 @@ TextureImporter:
       name: Walk_8
       rect:
         serializedVersion: 2
-        x: 32
-        y: 15
-        width: 32
-        height: 17
+        x: 0
+        y: 16
+        width: 16
+        height: 16
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -321,11 +321,165 @@ TextureImporter:
       indices: 
       edges: []
       weights: []
+    - serializedVersion: 2
+      name: Walk_9
+      rect:
+        serializedVersion: 2
+        x: 16
+        y: 16
+        width: 16
+        height: 16
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 3aa61a89464200449a85db8b0991cfca
+      internalID: 695513350
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Walk_10
+      rect:
+        serializedVersion: 2
+        x: 32
+        y: 16
+        width: 16
+        height: 16
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 87c503e323b9f4a4d8061bed6fb72092
+      internalID: 1648081557
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Walk_11
+      rect:
+        serializedVersion: 2
+        x: 48
+        y: 16
+        width: 16
+        height: 16
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: fedb9164410df214bb823c886d2db254
+      internalID: -1782430362
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Walk_12
+      rect:
+        serializedVersion: 2
+        x: 0
+        y: 0
+        width: 16
+        height: 16
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 9444c90824064564a9228ac75cd99bda
+      internalID: 563291288
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Walk_13
+      rect:
+        serializedVersion: 2
+        x: 16
+        y: 0
+        width: 16
+        height: 16
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 94dd254cc60f23d43b7866adbc47f45c
+      internalID: 1336053237
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Walk_14
+      rect:
+        serializedVersion: 2
+        x: 32
+        y: 0
+        width: 16
+        height: 16
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: d9311f253f4595d4ca8e67fd1ef21bea
+      internalID: 999112247
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Walk_15
+      rect:
+        serializedVersion: 2
+        x: 48
+        y: 0
+        width: 16
+        height: 16
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 555c8d6b26d395840a6cf9e1daadb834
+      internalID: -745718810
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
     outline: []
     customData: 
     physicsShape: []
     bones: []
-    spriteID: 
+    spriteID: 074205e9f93161a47b5e84cf1d6b5c5d
     internalID: 0
     vertices: []
     indices: 
@@ -333,10 +487,18 @@ TextureImporter:
     weights: []
     secondaryTextures: []
     spriteCustomMetadata:
-      entries: []
+      entries:
+      - key: SpriteEditor.SliceSettings
+        value: '{"sliceOnImport":false,"gridCellCount":{"x":1.0,"y":1.0},"gridSpriteSize":{"x":16.0,"y":16.0},"gridSpriteOffset":{"x":0.0,"y":0.0},"gridSpritePadding":{"x":0.0,"y":0.0},"pivot":{"x":0.5,"y":0.5},"pivotPixels":{"x":0.0,"y":0.0},"autoSlicingMethod":0,"spriteAlignment":0,"pivotUnitMode":0,"slicingType":1,"keepEmptyRects":false,"isAlternate":false}'
     nameFileIdTable:
       Walk_0: 4035959289877228764
       Walk_1: -982904232830982447
+      Walk_10: 1648081557
+      Walk_11: -1782430362
+      Walk_12: 563291288
+      Walk_13: 1336053237
+      Walk_14: 999112247
+      Walk_15: -745718810
       Walk_2: -350908408369970039
       Walk_3: -5409570386352685021
       Walk_4: 1553940418269799609
@@ -344,6 +506,7 @@ TextureImporter:
       Walk_6: -6428935122508569504
       Walk_7: 7144598999076838305
       Walk_8: 7500509103958437945
+      Walk_9: 695513350
   mipmapLimitGroupName: 
   pSDRemoveMatte: 0
   userData: 

--- a/Journey To The West/Assets/Sprites/Scammer/SeparateAnim/Attack.png.meta
+++ b/Journey To The West/Assets/Sprites/Scammer/SeparateAnim/Attack.png.meta
@@ -37,7 +37,7 @@ TextureImporter:
   maxTextureSize: 2048
   textureSettings:
     serializedVersion: 2
-    filterMode: 1
+    filterMode: 0
     aniso: 1
     mipBias: 0
     wrapU: 1
@@ -51,7 +51,7 @@ TextureImporter:
   spriteMeshType: 1
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
-  spritePixelsToUnits: 100
+  spritePixelsToUnits: 16
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
@@ -75,7 +75,7 @@ TextureImporter:
     maxTextureSize: 2048
     resizeAlgorithm: 0
     textureFormat: -1
-    textureCompression: 1
+    textureCompression: 2
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0
@@ -105,10 +105,10 @@ TextureImporter:
         serializedVersion: 2
         x: 0
         y: 0
-        width: 64
+        width: 16
         height: 16
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -121,11 +121,77 @@ TextureImporter:
       indices: 
       edges: []
       weights: []
+    - serializedVersion: 2
+      name: Attack_1
+      rect:
+        serializedVersion: 2
+        x: 16
+        y: 0
+        width: 16
+        height: 16
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: ffc9ee02aac807e4fab517f5b29da768
+      internalID: -861807607
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Attack_2
+      rect:
+        serializedVersion: 2
+        x: 32
+        y: 0
+        width: 16
+        height: 16
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 8a2b51d1c7b87c44ab27a06b719b544e
+      internalID: 666022993
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Attack_3
+      rect:
+        serializedVersion: 2
+        x: 48
+        y: 0
+        width: 16
+        height: 16
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: da1e700d9bf7d3a4fb5b9acb3656bd3a
+      internalID: 1294306720
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
     outline: []
     customData: 
     physicsShape: []
     bones: []
-    spriteID: 
+    spriteID: 202cb64ab9deefc4fa5d2c56f06b61f0
     internalID: 0
     vertices: []
     indices: 
@@ -133,9 +199,14 @@ TextureImporter:
     weights: []
     secondaryTextures: []
     spriteCustomMetadata:
-      entries: []
+      entries:
+      - key: SpriteEditor.SliceSettings
+        value: '{"sliceOnImport":false,"gridCellCount":{"x":1.0,"y":1.0},"gridSpriteSize":{"x":16.0,"y":16.0},"gridSpriteOffset":{"x":0.0,"y":0.0},"gridSpritePadding":{"x":0.0,"y":0.0},"pivot":{"x":0.5,"y":0.5},"pivotPixels":{"x":0.0,"y":0.0},"autoSlicingMethod":0,"spriteAlignment":0,"pivotUnitMode":0,"slicingType":1,"keepEmptyRects":false,"isAlternate":false}'
     nameFileIdTable:
       Attack_0: -7008412969330441016
+      Attack_1: -861807607
+      Attack_2: 666022993
+      Attack_3: 1294306720
   mipmapLimitGroupName: 
   pSDRemoveMatte: 0
   userData: 

--- a/Journey To The West/Assets/Sprites/Scammer/SeparateAnim/Idle.png.meta
+++ b/Journey To The West/Assets/Sprites/Scammer/SeparateAnim/Idle.png.meta
@@ -37,7 +37,7 @@ TextureImporter:
   maxTextureSize: 2048
   textureSettings:
     serializedVersion: 2
-    filterMode: 1
+    filterMode: 0
     aniso: 1
     mipBias: 0
     wrapU: 1
@@ -51,7 +51,7 @@ TextureImporter:
   spriteMeshType: 1
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
-  spritePixelsToUnits: 100
+  spritePixelsToUnits: 16
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
@@ -75,7 +75,7 @@ TextureImporter:
     maxTextureSize: 2048
     resizeAlgorithm: 0
     textureFormat: -1
-    textureCompression: 1
+    textureCompression: 2
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0
@@ -105,10 +105,10 @@ TextureImporter:
         serializedVersion: 2
         x: 0
         y: 0
-        width: 64
+        width: 16
         height: 16
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -121,11 +121,77 @@ TextureImporter:
       indices: 
       edges: []
       weights: []
+    - serializedVersion: 2
+      name: Idle_1
+      rect:
+        serializedVersion: 2
+        x: 16
+        y: 0
+        width: 16
+        height: 16
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 97f4b427b467c984eb3530f5d6a71b1c
+      internalID: -1451311899
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Idle_2
+      rect:
+        serializedVersion: 2
+        x: 32
+        y: 0
+        width: 16
+        height: 16
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 2fa4800e6128cc94981b05f690382e6c
+      internalID: 1249232488
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Idle_3
+      rect:
+        serializedVersion: 2
+        x: 48
+        y: 0
+        width: 16
+        height: 16
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: d9d4596d681124a458676558082a1ccf
+      internalID: 652850686
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
     outline: []
     customData: 
     physicsShape: []
     bones: []
-    spriteID: 
+    spriteID: a0daca464b562484185e0f39de8f9bd8
     internalID: 0
     vertices: []
     indices: 
@@ -133,9 +199,14 @@ TextureImporter:
     weights: []
     secondaryTextures: []
     spriteCustomMetadata:
-      entries: []
+      entries:
+      - key: SpriteEditor.SliceSettings
+        value: '{"sliceOnImport":false,"gridCellCount":{"x":1.0,"y":1.0},"gridSpriteSize":{"x":16.0,"y":16.0},"gridSpriteOffset":{"x":0.0,"y":0.0},"gridSpritePadding":{"x":0.0,"y":0.0},"pivot":{"x":0.5,"y":0.5},"pivotPixels":{"x":0.0,"y":0.0},"autoSlicingMethod":0,"spriteAlignment":0,"pivotUnitMode":0,"slicingType":1,"keepEmptyRects":false,"isAlternate":false}'
     nameFileIdTable:
       Idle_0: 4723107735738678597
+      Idle_1: -1451311899
+      Idle_2: 1249232488
+      Idle_3: 652850686
   mipmapLimitGroupName: 
   pSDRemoveMatte: 0
   userData: 

--- a/Journey To The West/Assets/Sprites/Scammer/SeparateAnim/Walk.png.meta
+++ b/Journey To The West/Assets/Sprites/Scammer/SeparateAnim/Walk.png.meta
@@ -46,7 +46,7 @@ TextureImporter:
   maxTextureSize: 2048
   textureSettings:
     serializedVersion: 2
-    filterMode: 1
+    filterMode: 0
     aniso: 1
     mipBias: 0
     wrapU: 1
@@ -60,7 +60,7 @@ TextureImporter:
   spriteMeshType: 1
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
-  spritePixelsToUnits: 100
+  spritePixelsToUnits: 16
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
@@ -84,7 +84,7 @@ TextureImporter:
     maxTextureSize: 2048
     resizeAlgorithm: 0
     textureFormat: -1
-    textureCompression: 1
+    textureCompression: 2
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0
@@ -113,11 +113,11 @@ TextureImporter:
       rect:
         serializedVersion: 2
         x: 0
-        y: 47
-        width: 64
-        height: 17
+        y: 48
+        width: 16
+        height: 16
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -134,12 +134,12 @@ TextureImporter:
       name: Walk_1
       rect:
         serializedVersion: 2
-        x: 0
-        y: 31
-        width: 64
+        x: 16
+        y: 48
+        width: 16
         height: 16
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -156,12 +156,12 @@ TextureImporter:
       name: Walk_2
       rect:
         serializedVersion: 2
-        x: 0
-        y: 15
-        width: 64
-        height: 17
+        x: 32
+        y: 48
+        width: 16
+        height: 16
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -178,12 +178,12 @@ TextureImporter:
       name: Walk_3
       rect:
         serializedVersion: 2
-        x: 0
-        y: 0
-        width: 64
-        height: 15
+        x: 48
+        y: 48
+        width: 16
+        height: 16
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []
@@ -196,11 +196,275 @@ TextureImporter:
       indices: 
       edges: []
       weights: []
+    - serializedVersion: 2
+      name: Walk_4
+      rect:
+        serializedVersion: 2
+        x: 0
+        y: 32
+        width: 16
+        height: 16
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: f7ba0a136d0ffad449f57bb578dcdfe6
+      internalID: -1070111882
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Walk_5
+      rect:
+        serializedVersion: 2
+        x: 16
+        y: 32
+        width: 16
+        height: 16
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 54b2306179abc144d9026340fd4fa9d1
+      internalID: -258869128
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Walk_6
+      rect:
+        serializedVersion: 2
+        x: 32
+        y: 32
+        width: 16
+        height: 16
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: ba110785dfaa79f4e95b7eaaacb95e76
+      internalID: 1395707758
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Walk_7
+      rect:
+        serializedVersion: 2
+        x: 48
+        y: 32
+        width: 16
+        height: 16
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 6dca4eed4e48a654cac038ff74a4ca0d
+      internalID: 967042945
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Walk_8
+      rect:
+        serializedVersion: 2
+        x: 0
+        y: 16
+        width: 16
+        height: 16
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: d6176eb4f75336742b773449c377ac0f
+      internalID: -191942432
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Walk_9
+      rect:
+        serializedVersion: 2
+        x: 16
+        y: 16
+        width: 16
+        height: 16
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 2b504d42b7510dd4a9a7145a4b4cbd27
+      internalID: -1151903921
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Walk_10
+      rect:
+        serializedVersion: 2
+        x: 32
+        y: 16
+        width: 16
+        height: 16
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 9bb46fc6218843748ab8ff53efa6416f
+      internalID: -531119815
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Walk_11
+      rect:
+        serializedVersion: 2
+        x: 48
+        y: 16
+        width: 16
+        height: 16
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 9aabb7242688ff544a8e4cc53288fa91
+      internalID: 1833484480
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Walk_12
+      rect:
+        serializedVersion: 2
+        x: 0
+        y: 0
+        width: 16
+        height: 16
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: a2e8f2a4238645b4cbfab2c0cdd77086
+      internalID: 1609967264
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Walk_13
+      rect:
+        serializedVersion: 2
+        x: 16
+        y: 0
+        width: 16
+        height: 16
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: a6cfdc9876bf4fd4eaa5b79fbfa1f3cb
+      internalID: 944902872
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Walk_14
+      rect:
+        serializedVersion: 2
+        x: 32
+        y: 0
+        width: 16
+        height: 16
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 40b1ca67bfff9574da88bd0a63ffea19
+      internalID: 1768821728
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Walk_15
+      rect:
+        serializedVersion: 2
+        x: 48
+        y: 0
+        width: 16
+        height: 16
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 173b9f42d6793e549bf9c698bf395c63
+      internalID: 635422702
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
     outline: []
     customData: 
     physicsShape: []
     bones: []
-    spriteID: 
+    spriteID: 987d8d690229104409403a723bc0b130
     internalID: 0
     vertices: []
     indices: 
@@ -208,12 +472,26 @@ TextureImporter:
     weights: []
     secondaryTextures: []
     spriteCustomMetadata:
-      entries: []
+      entries:
+      - key: SpriteEditor.SliceSettings
+        value: '{"sliceOnImport":false,"gridCellCount":{"x":1.0,"y":1.0},"gridSpriteSize":{"x":16.0,"y":16.0},"gridSpriteOffset":{"x":0.0,"y":0.0},"gridSpritePadding":{"x":0.0,"y":0.0},"pivot":{"x":0.5,"y":0.5},"pivotPixels":{"x":0.0,"y":0.0},"autoSlicingMethod":0,"spriteAlignment":0,"pivotUnitMode":0,"slicingType":1,"keepEmptyRects":false,"isAlternate":false}'
     nameFileIdTable:
       Walk_0: 4035959289877228764
       Walk_1: -982904232830982447
+      Walk_10: -531119815
+      Walk_11: 1833484480
+      Walk_12: 1609967264
+      Walk_13: 944902872
+      Walk_14: 1768821728
+      Walk_15: 635422702
       Walk_2: -350908408369970039
       Walk_3: -5409570386352685021
+      Walk_4: -1070111882
+      Walk_5: -258869128
+      Walk_6: 1395707758
+      Walk_7: 967042945
+      Walk_8: -191942432
+      Walk_9: -1151903921
   mipmapLimitGroupName: 
   pSDRemoveMatte: 0
   userData: 


### PR DESCRIPTION
Add CharacterSpriteSwapper that remaps default (Jin) sprites to the chosen style's equivalent sprites in LateUpdate, so existing animations work untouched. An Editor tool (Tools > Setup Hustle Style Sprites) auto-populates the sprite arrays on each HustleStyleData asset.

Closes #55 