### PR TITLE
fix: shield/HP greed scaling, quest persistence, UI persistence, and scene transitions

### DIFF
--- a/Journey To The West/Assets/Prefabs/PlayerOriginal.prefab
+++ b/Journey To The West/Assets/Prefabs/PlayerOriginal.prefab
@@ -162,7 +162,7 @@ SpriteRenderer:
   m_LightmapParameters: {fileID: 0}
   m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 1167505161
-  m_SortingLayer: 4
+  m_SortingLayer: 6
   m_SortingOrder: 100
   m_MaskInteraction: 0
   m_Sprite: {fileID: 21300000, guid: 3ffb30098bec37f4bb0e6d251f6e2100, type: 3}
@@ -265,7 +265,7 @@ GameObject:
   - component: {fileID: 281105376200213791}
   - component: {fileID: 993695842324409041}
   m_Layer: 0
-  m_Name: Player
+  m_Name: PlayerOriginal
   m_TagString: Player
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -334,7 +334,7 @@ SpriteRenderer:
   m_LightmapParameters: {fileID: 0}
   m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 1167505161
-  m_SortingLayer: 4
+  m_SortingLayer: 6
   m_SortingOrder: 0
   m_MaskInteraction: 0
   m_Sprite: {fileID: 4723107735738678597, guid: 24d67b8d650dad64a958cdf424dbd088, type: 3}
@@ -507,6 +507,10 @@ MonoBehaviour:
       m_Calls: []
     m_ActionId: 3e92f002-3b28-48ed-8f76-f5207449abae
     m_ActionName: 'Player/HUDTestGold[/Keyboard/g]'
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+    m_ActionName: 'Player/Skill[/Mouse/rightButton]'
   m_NeverAutoSwitchControlSchemes: 0
   m_DefaultControlScheme: 
   m_DefaultActionMap: Player
@@ -525,6 +529,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::PlayerController
   moveSpeed: 5
+  sprintSpeedMultiplier: 2
+  forcedMoveSpeedMultiplier: 0.5
+  tileSize: 1
+  hotbar: {fileID: 0}
 --- !u!95 &146939367618497807
 Animator:
   serializedVersion: 7
@@ -642,12 +650,21 @@ MonoBehaviour:
   OnSkillActivated:
     m_PersistentCalls:
       m_Calls: []
+  OnSkillCooldownReset:
+    m_PersistentCalls:
+      m_Calls: []
+  OnSkillEquipped:
+    m_PersistentCalls:
+      m_Calls: []
   baseMaxHP: 100
   baseDamage: 10
   attackCooldown: 0.1
   equippedSkill: {fileID: 0}
   equippedArmor: {fileID: 0}
+  defaultSkill: {fileID: 0}
   droppedGoldPrefab: {fileID: 5710133168742629414, guid: bb7a800c10583ec4ca8ff1e6217da669, type: 3}
+  deathGoldLossAmount: 20
+  dashAttackHandler: {fileID: 0}
   flashDuration: 0.1
   flashColor: {r: 1, g: 0, b: 0, a: 1}
 --- !u!114 &993695842324409041

--- a/Journey To The West/Assets/Scenes/Main.unity
+++ b/Journey To The West/Assets/Scenes/Main.unity
@@ -562,6 +562,11 @@ SpriteRenderer:
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1
   m_SpriteSortPoint: 0
+--- !u!224 &82340206 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 324305415555439952, guid: 737607d88ee454ad69f1b4b9214c7805, type: 3}
+  m_PrefabInstance: {fileID: 3450776239777152415}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &99835313
 GameObject:
   m_ObjectHideFlags: 0
@@ -1063,17 +1068,16 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8360f322c0c684f4e9e93aa717600c6d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::StealthDetector
-  unawareRange: 4
+  unawareRange: 8
   alertedRange: 10
-  fieldOfViewAngle: 90
   obstacleLayers:
     serializedVersion: 2
     m_Bits: 768
   timeToAlert: 0
   drainDelay: 0.5
   timeToCalm: 4
-  suspicionIcon: {fileID: 0}
-  alertIcon: {fileID: 0}
+  mediumThreshold: 0.33
+  highThreshold: 0.66
 --- !u!95 &153144271
 Animator:
   serializedVersion: 7
@@ -1142,6 +1146,8 @@ MonoBehaviour:
   npcName: Shrine of Yun'Shul
   faceSprite: {fileID: 0}
   interactionIcon: {fileID: 429958014}
+  exclamationSprite: {fileID: 0}
+  exclamationOffset: {x: 0, y: 1.5, z: 0}
   dialoguePanel: {fileID: 841510794}
   dialogueText: {fileID: 830678581}
   nameText: {fileID: 6439881}
@@ -1388,17 +1394,16 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8360f322c0c684f4e9e93aa717600c6d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::StealthDetector
-  unawareRange: 4
+  unawareRange: 8
   alertedRange: 10
-  fieldOfViewAngle: 90
   obstacleLayers:
     serializedVersion: 2
     m_Bits: 768
   timeToAlert: 0
   drainDelay: 0.5
   timeToCalm: 4
-  suspicionIcon: {fileID: 0}
-  alertIcon: {fileID: 0}
+  mediumThreshold: 0.33
+  highThreshold: 0.66
 --- !u!95 &185167076
 Animator:
   serializedVersion: 7
@@ -1547,7 +1552,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4aa2272a51f01f648aaefce28dce9df8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::EnemyShield
-  shieldCount: 3
+  shieldCount: 1
   shieldIconContainer: {fileID: 613554631}
   iconSpacing: 0.3
 --- !u!114 &194754929
@@ -1610,17 +1615,16 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8360f322c0c684f4e9e93aa717600c6d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::StealthDetector
-  unawareRange: 4
+  unawareRange: 8
   alertedRange: 10
-  fieldOfViewAngle: 90
   obstacleLayers:
     serializedVersion: 2
     m_Bits: 768
   timeToAlert: 0
   drainDelay: 0.5
   timeToCalm: 4
-  suspicionIcon: {fileID: 0}
-  alertIcon: {fileID: 0}
+  mediumThreshold: 0.33
+  highThreshold: 0.66
 --- !u!95 &194754932
 Animator:
   serializedVersion: 7
@@ -1735,7 +1739,7 @@ BoxCollider2D:
   m_UsedByEffector: 0
   m_CompositeOperation: 0
   m_CompositeOrder: 0
-  m_Offset: {x: 0.5142498, y: -3.6943407}
+  m_Offset: {x: 0.5142498, y: -4.1593695}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0, y: 0}
@@ -1745,7 +1749,7 @@ BoxCollider2D:
     drawMode: 0
     adaptiveTiling: 0
   m_AutoTiling: 0
-  m_Size: {x: 0.30150223, y: 14.062166}
+  m_Size: {x: 0.30150223, y: 14.992224}
   m_EdgeRadius: 0
 --- !u!1 &201237747
 GameObject:
@@ -1779,6 +1783,143 @@ Transform:
   - {fileID: 1647007466}
   m_Father: {fileID: 649579830}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &205948711
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 205948714}
+  - component: {fileID: 205948713}
+  - component: {fileID: 205948712}
+  m_Layer: 5
+  m_Name: RedPacketLabelText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &205948712
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 205948711}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 'RED  PACKETS: '
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 70a81763098886148b3ad1285615965b, type: 2}
+  m_sharedMaterial: {fileID: 829339057539629669, guid: 70a81763098886148b3ad1285615965b, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4278190080
+  m_fontColor: {r: 0, g: 0, b: 0, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 60
+  m_fontSizeBase: 60
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 1024
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: -409.98035, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &205948713
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 205948711}
+  m_CullTransparentMesh: 1
+--- !u!224 &205948714
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 205948711}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1574335320}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -647, y: -238}
+  m_SizeDelta: {x: 200, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &233330098
 GameObject:
   m_ObjectHideFlags: 0
@@ -1880,17 +2021,16 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8360f322c0c684f4e9e93aa717600c6d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::StealthDetector
-  unawareRange: 4
+  unawareRange: 8
   alertedRange: 10
-  fieldOfViewAngle: 90
   obstacleLayers:
     serializedVersion: 2
     m_Bits: 768
   timeToAlert: 0
   drainDelay: 0.5
   timeToCalm: 4
-  suspicionIcon: {fileID: 0}
-  alertIcon: {fileID: 0}
+  mediumThreshold: 0.33
+  highThreshold: 0.66
 --- !u!95 &233924751
 Animator:
   serializedVersion: 7
@@ -2228,17 +2368,16 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8360f322c0c684f4e9e93aa717600c6d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::StealthDetector
-  unawareRange: 4
+  unawareRange: 8
   alertedRange: 10
-  fieldOfViewAngle: 90
   obstacleLayers:
     serializedVersion: 2
     m_Bits: 768
   timeToAlert: 0
   drainDelay: 0.5
   timeToCalm: 4
-  suspicionIcon: {fileID: 0}
-  alertIcon: {fileID: 0}
+  mediumThreshold: 0.33
+  highThreshold: 0.66
 --- !u!95 &287278381
 Animator:
   serializedVersion: 7
@@ -2274,6 +2413,67 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::EnemyDeathEffect
   deathParticlePrefab: {fileID: 4713161626215706932, guid: 4fd72346c0c41c442ba884730a730f4d, type: 3}
+--- !u!1001 &290751110
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 911929358177466543, guid: d1fce84f2ce091744b6b20dea7dffd67, type: 3}
+      propertyPath: m_Name
+      value: StrongEnemy (3)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3360201154032765571, guid: d1fce84f2ce091744b6b20dea7dffd67, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.07
+      objectReference: {fileID: 0}
+    - target: {fileID: 3360201154032765571, guid: d1fce84f2ce091744b6b20dea7dffd67, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 34.53
+      objectReference: {fileID: 0}
+    - target: {fileID: 3360201154032765571, guid: d1fce84f2ce091744b6b20dea7dffd67, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3360201154032765571, guid: d1fce84f2ce091744b6b20dea7dffd67, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3360201154032765571, guid: d1fce84f2ce091744b6b20dea7dffd67, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3360201154032765571, guid: d1fce84f2ce091744b6b20dea7dffd67, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3360201154032765571, guid: d1fce84f2ce091744b6b20dea7dffd67, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3360201154032765571, guid: d1fce84f2ce091744b6b20dea7dffd67, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3360201154032765571, guid: d1fce84f2ce091744b6b20dea7dffd67, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3360201154032765571, guid: d1fce84f2ce091744b6b20dea7dffd67, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3828077422619850012, guid: d1fce84f2ce091744b6b20dea7dffd67, type: 3}
+      propertyPath: shieldCount
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d1fce84f2ce091744b6b20dea7dffd67, type: 3}
 --- !u!1 &296328972
 GameObject:
   m_ObjectHideFlags: 0
@@ -2576,17 +2776,16 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8360f322c0c684f4e9e93aa717600c6d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::StealthDetector
-  unawareRange: 4
+  unawareRange: 8
   alertedRange: 10
-  fieldOfViewAngle: 90
   obstacleLayers:
     serializedVersion: 2
     m_Bits: 768
   timeToAlert: 0
   drainDelay: 0.5
   timeToCalm: 4
-  suspicionIcon: {fileID: 0}
-  alertIcon: {fileID: 0}
+  mediumThreshold: 0.33
+  highThreshold: 0.66
 --- !u!95 &298410039
 Animator:
   serializedVersion: 7
@@ -2959,7 +3158,7 @@ BoxCollider2D:
   m_UsedByEffector: 0
   m_CompositeOperation: 0
   m_CompositeOrder: 0
-  m_Offset: {x: -0.12153816, y: 0.38231754}
+  m_Offset: {x: 10.874104, y: 0.38231754}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0, y: 0}
@@ -2969,119 +3168,8 @@ BoxCollider2D:
     drawMode: 0
     adaptiveTiling: 0
   m_AutoTiling: 0
-  m_Size: {x: 8.259678, y: 0.32636452}
+  m_Size: {x: 42.005295, y: 0.32636452}
   m_EdgeRadius: 0
---- !u!1 &331316277 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 7149265674548169254, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-  m_PrefabInstance: {fileID: 628957442}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &331316278
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 331316277}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b7c0a97a28c082d4bace224a35255c76, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: Assembly-CSharp::RangedEnemy
-  enemyData: {fileID: 11400000, guid: 214d017a58ffb2744a6687d0b5800214, type: 2}
-  projectilePrefab: {fileID: 8297447480537988912, guid: a98a98f6aa000b045bb45a9944e3ac9f, type: 3}
-  waypoints: []
-  droppedGoldPrefab: {fileID: 5710133168742629414, guid: bb7a800c10583ec4ca8ff1e6217da669, type: 3}
-  obstacleLayers:
-    serializedVersion: 2
-    m_Bits: 256
-  flashDuration: 0.1
-  flashColor: {r: 1, g: 0, b: 0, a: 1}
---- !u!50 &331316279
-Rigidbody2D:
-  serializedVersion: 5
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 331316277}
-  m_BodyType: 0
-  m_Simulated: 1
-  m_UseFullKinematicContacts: 0
-  m_UseAutoMass: 0
-  m_Mass: 1
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_GravityScale: 1
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_Interpolate: 0
-  m_SleepingMode: 1
-  m_CollisionDetection: 0
-  m_Constraints: 0
---- !u!114 &331316280
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 331316277}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8360f322c0c684f4e9e93aa717600c6d, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: Assembly-CSharp::StealthDetector
-  unawareRange: 4
-  alertedRange: 10
-  fieldOfViewAngle: 90
-  obstacleLayers:
-    serializedVersion: 2
-    m_Bits: 256
-  timeToAlert: 1.5
-  drainDelay: 0.5
-  timeToCalm: 4
-  suspicionIcon: {fileID: 0}
-  alertIcon: {fileID: 0}
---- !u!95 &331316281
-Animator:
-  serializedVersion: 7
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 331316277}
-  m_Enabled: 1
-  m_Avatar: {fileID: 0}
-  m_Controller: {fileID: 0}
-  m_CullingMode: 0
-  m_UpdateMode: 0
-  m_ApplyRootMotion: 0
-  m_LinearVelocityBlending: 0
-  m_StabilizeFeet: 0
-  m_AnimatePhysics: 0
-  m_WarningMessage: 
-  m_HasTransformHierarchy: 1
-  m_AllowConstantClipSamplingOptimization: 1
-  m_KeepAnimatorStateOnDisable: 0
-  m_WriteDefaultValuesOnDisable: 0
---- !u!114 &331316282
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 331316277}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 18dd39af2626ab64597bb0cd8dfc08da, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: Assembly-CSharp::EnemyDeathEffect
-  deathParticlePrefab: {fileID: 4713161626215706932, guid: 4fd72346c0c41c442ba884730a730f4d, type: 3}
 --- !u!1 &331632751
 GameObject:
   m_ObjectHideFlags: 0
@@ -3161,7 +3249,7 @@ BoxCollider2D:
   m_UsedByEffector: 0
   m_CompositeOperation: 0
   m_CompositeOrder: 0
-  m_Offset: {x: 0.3653221, y: 0.83785915}
+  m_Offset: {x: 0.3653221, y: 0.38943958}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0, y: 0}
@@ -3171,7 +3259,7 @@ BoxCollider2D:
     drawMode: 0
     adaptiveTiling: 0
   m_AutoTiling: 0
-  m_Size: {x: 0.31902313, y: 12.008707}
+  m_Size: {x: 0.31902313, y: 12.905546}
   m_EdgeRadius: 0
 --- !u!1 &334681388
 GameObject:
@@ -3394,6 +3482,8 @@ MonoBehaviour:
   npcName: Dojo Master
   faceSprite: {fileID: 0}
   interactionIcon: {fileID: 2061362790}
+  exclamationSprite: {fileID: 0}
+  exclamationOffset: {x: 0, y: 1.5, z: 0}
   dialoguePanel: {fileID: 841510794}
   dialogueText: {fileID: 830678581}
   nameText: {fileID: 6439881}
@@ -3642,17 +3732,16 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8360f322c0c684f4e9e93aa717600c6d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::StealthDetector
-  unawareRange: 4
+  unawareRange: 8
   alertedRange: 10
-  fieldOfViewAngle: 90
   obstacleLayers:
     serializedVersion: 2
     m_Bits: 768
   timeToAlert: 0
   drainDelay: 0.5
   timeToCalm: 4
-  suspicionIcon: {fileID: 0}
-  alertIcon: {fileID: 0}
+  mediumThreshold: 0.33
+  highThreshold: 0.66
 --- !u!95 &382667660
 Animator:
   serializedVersion: 7
@@ -3807,6 +3896,11 @@ PrefabInstance:
       insertIndex: -1
       addedObject: {fileID: 649579831}
   m_SourcePrefab: {fileID: 100100000, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
+--- !u!1 &395068173 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 432460049451275601, guid: 737607d88ee454ad69f1b4b9214c7805, type: 3}
+  m_PrefabInstance: {fileID: 3450776239777152415}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &395787951
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3990,17 +4084,16 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8360f322c0c684f4e9e93aa717600c6d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::StealthDetector
-  unawareRange: 4
+  unawareRange: 8
   alertedRange: 10
-  fieldOfViewAngle: 90
   obstacleLayers:
     serializedVersion: 2
     m_Bits: 768
   timeToAlert: 0
   drainDelay: 0.5
   timeToCalm: 4
-  suspicionIcon: {fileID: 0}
-  alertIcon: {fileID: 0}
+  mediumThreshold: 0.33
+  highThreshold: 0.66
 --- !u!95 &408907785
 Animator:
   serializedVersion: 7
@@ -4180,7 +4273,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4aa2272a51f01f648aaefce28dce9df8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::EnemyShield
-  shieldCount: 3
+  shieldCount: 1
   shieldIconContainer: {fileID: 838064809}
   iconSpacing: 0.3
 --- !u!114 &432232185
@@ -4243,17 +4336,16 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8360f322c0c684f4e9e93aa717600c6d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::StealthDetector
-  unawareRange: 4
+  unawareRange: 8
   alertedRange: 10
-  fieldOfViewAngle: 90
   obstacleLayers:
     serializedVersion: 2
     m_Bits: 768
   timeToAlert: 0
   drainDelay: 0.5
   timeToCalm: 4
-  suspicionIcon: {fileID: 0}
-  alertIcon: {fileID: 0}
+  mediumThreshold: 0.33
+  highThreshold: 0.66
 --- !u!95 &432232188
 Animator:
   serializedVersion: 7
@@ -25495,119 +25587,6 @@ Transform:
   - {fileID: 129837352}
   m_Father: {fileID: 1367584290}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &507215398
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 2389927335297099617, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: flashColor.b
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2389927335297099617, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: flashColor.g
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2389927335297099617, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: flashColor.r
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2591260189200705611, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 5546671543968653177, guid: ed46feb04f87a3544a05e6e5d539b5cb, type: 3}
-    - target: {fileID: 2591260189200705611, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: m_SortingLayer
-      value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: 2591260189200705611, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: m_SortingLayerID
-      value: 1167505161
-      objectReference: {fileID: 0}
-    - target: {fileID: 6425784204000495687, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: m_Size.x
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6425784204000495687, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: m_Size.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6425784204000495687, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: m_IsTrigger
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6926554811131377722, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0.22
-      objectReference: {fileID: 0}
-    - target: {fileID: 6926554811131377722, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 34.41
-      objectReference: {fileID: 0}
-    - target: {fileID: 6926554811131377722, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6926554811131377722, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6926554811131377722, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6926554811131377722, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6926554811131377722, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6926554811131377722, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6926554811131377722, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6926554811131377722, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7149265674548169254, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: m_Name
-      value: DummyEnemy (4)
-      objectReference: {fileID: 0}
-    - target: {fileID: 7149265674548169254, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: m_IsActive
-      value: 1
-      objectReference: {fileID: 0}
-    m_RemovedComponents:
-    - {fileID: 2389927335297099617, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 7149265674548169254, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 941169610}
-    - targetCorrespondingSourceObject: {fileID: 7149265674548169254, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 941169609}
-    - targetCorrespondingSourceObject: {fileID: 7149265674548169254, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 941169608}
-    - targetCorrespondingSourceObject: {fileID: 7149265674548169254, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 941169607}
-    - targetCorrespondingSourceObject: {fileID: 7149265674548169254, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 941169606}
-  m_SourcePrefab: {fileID: 100100000, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
 --- !u!1 &507877747
 GameObject:
   m_ObjectHideFlags: 0
@@ -25681,6 +25660,8 @@ MonoBehaviour:
   npcName: Village Elder
   faceSprite: {fileID: -7527145504033472756, guid: a7b9de86dd332fc4eb204ef08c7d734e, type: 3}
   interactionIcon: {fileID: 1485742815}
+  exclamationSprite: {fileID: 0}
+  exclamationOffset: {x: 0, y: 1.5, z: 0}
   dialoguePanel: {fileID: 841510794}
   dialogueText: {fileID: 830678581}
   nameText: {fileID: 6439881}
@@ -25981,7 +25962,7 @@ Transform:
   m_GameObject: {fileID: 519420028}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -0.5698137, y: -12.49477, z: -10}
+  m_LocalPosition: {x: -0.5662488, y: -12.49477, z: -10}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -26041,7 +26022,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4aa2272a51f01f648aaefce28dce9df8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::EnemyShield
-  shieldCount: 3
+  shieldCount: 1
   shieldIconContainer: {fileID: 1198157117}
   iconSpacing: 0.3
 --- !u!114 &527006458
@@ -26104,17 +26085,16 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8360f322c0c684f4e9e93aa717600c6d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::StealthDetector
-  unawareRange: 4
+  unawareRange: 8
   alertedRange: 10
-  fieldOfViewAngle: 90
   obstacleLayers:
     serializedVersion: 2
     m_Bits: 768
   timeToAlert: 0
   drainDelay: 0.5
   timeToCalm: 4
-  suspicionIcon: {fileID: 0}
-  alertIcon: {fileID: 0}
+  mediumThreshold: 0.33
+  highThreshold: 0.66
 --- !u!95 &527006461
 Animator:
   serializedVersion: 7
@@ -26739,119 +26719,6 @@ PrefabInstance:
       insertIndex: -1
       addedObject: {fileID: 233924748}
   m_SourcePrefab: {fileID: 100100000, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
---- !u!1001 &628957442
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 2389927335297099617, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: flashColor.b
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2389927335297099617, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: flashColor.g
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2389927335297099617, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: flashColor.r
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2591260189200705611, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 5546671543968653177, guid: ed46feb04f87a3544a05e6e5d539b5cb, type: 3}
-    - target: {fileID: 2591260189200705611, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: m_SortingLayer
-      value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: 2591260189200705611, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: m_SortingLayerID
-      value: 1167505161
-      objectReference: {fileID: 0}
-    - target: {fileID: 6425784204000495687, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: m_Size.x
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6425784204000495687, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: m_Size.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6425784204000495687, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: m_IsTrigger
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6926554811131377722, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 4.92
-      objectReference: {fileID: 0}
-    - target: {fileID: 6926554811131377722, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 24.98
-      objectReference: {fileID: 0}
-    - target: {fileID: 6926554811131377722, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6926554811131377722, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6926554811131377722, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6926554811131377722, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6926554811131377722, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6926554811131377722, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6926554811131377722, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6926554811131377722, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7149265674548169254, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: m_Name
-      value: DummyEnemy (2)
-      objectReference: {fileID: 0}
-    - target: {fileID: 7149265674548169254, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: m_IsActive
-      value: 1
-      objectReference: {fileID: 0}
-    m_RemovedComponents:
-    - {fileID: 2389927335297099617, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 7149265674548169254, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 331316282}
-    - targetCorrespondingSourceObject: {fileID: 7149265674548169254, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 331316281}
-    - targetCorrespondingSourceObject: {fileID: 7149265674548169254, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 331316280}
-    - targetCorrespondingSourceObject: {fileID: 7149265674548169254, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 331316279}
-    - targetCorrespondingSourceObject: {fileID: 7149265674548169254, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 331316278}
-  m_SourcePrefab: {fileID: 100100000, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
 --- !u!1 &649579829 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 7149265674548169254, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
@@ -26874,7 +26741,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4aa2272a51f01f648aaefce28dce9df8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::EnemyShield
-  shieldCount: 3
+  shieldCount: 1
   shieldIconContainer: {fileID: 201237747}
   iconSpacing: 0.3
 --- !u!114 &649579832
@@ -26937,17 +26804,16 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8360f322c0c684f4e9e93aa717600c6d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::StealthDetector
-  unawareRange: 4
+  unawareRange: 8
   alertedRange: 10
-  fieldOfViewAngle: 90
   obstacleLayers:
     serializedVersion: 2
     m_Bits: 768
   timeToAlert: 0
   drainDelay: 0.5
   timeToCalm: 4
-  suspicionIcon: {fileID: 0}
-  alertIcon: {fileID: 0}
+  mediumThreshold: 0.33
+  highThreshold: 0.66
 --- !u!95 &649579835
 Animator:
   serializedVersion: 7
@@ -27067,6 +26933,11 @@ PolygonCollider2D:
       - {x: -8.989574, y: -3.0944924}
       - {x: 9.599283, y: -3.211132}
   m_UseDelaunayMesh: 1
+--- !u!1 &671340672 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1405046755992410545, guid: da0c0c8dc895e94498aa675def287ec6, type: 3}
+  m_PrefabInstance: {fileID: 3334623305622404976}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &676735322
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -27454,17 +27325,16 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8360f322c0c684f4e9e93aa717600c6d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::StealthDetector
-  unawareRange: 4
+  unawareRange: 8
   alertedRange: 10
-  fieldOfViewAngle: 90
   obstacleLayers:
     serializedVersion: 2
     m_Bits: 768
   timeToAlert: 0
   drainDelay: 0.5
   timeToCalm: 4
-  suspicionIcon: {fileID: 0}
-  alertIcon: {fileID: 0}
+  mediumThreshold: 0.33
+  highThreshold: 0.66
 --- !u!95 &708345816
 Animator:
   serializedVersion: 7
@@ -27693,17 +27563,16 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8360f322c0c684f4e9e93aa717600c6d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::StealthDetector
-  unawareRange: 4
+  unawareRange: 8
   alertedRange: 10
-  fieldOfViewAngle: 90
   obstacleLayers:
     serializedVersion: 2
     m_Bits: 768
   timeToAlert: 0
   drainDelay: 0.5
   timeToCalm: 4
-  suspicionIcon: {fileID: 0}
-  alertIcon: {fileID: 0}
+  mediumThreshold: 0.33
+  highThreshold: 0.66
 --- !u!95 &723540777
 Animator:
   serializedVersion: 7
@@ -27997,6 +27866,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::SceneTeleporter
   targetSceneAsset: {fileID: 102900000, guid: 74bf44d60a76f3f47a27de149b250535, type: 3}
   targetScene: SnowyTown
+  targetSpawnId: from_town_a
 --- !u!61 &782213230
 BoxCollider2D:
   m_ObjectHideFlags: 0
@@ -28241,7 +28111,7 @@ BoxCollider2D:
   m_UsedByEffector: 0
   m_CompositeOperation: 0
   m_CompositeOrder: 0
-  m_Offset: {x: 0.5142498, y: 1.8537388}
+  m_Offset: {x: 0.5142498, y: 6.193838}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0, y: 0}
@@ -28251,7 +28121,7 @@ BoxCollider2D:
     drawMode: 0
     adaptiveTiling: 0
   m_AutoTiling: 0
-  m_Size: {x: 0.30150223, y: 5.6520424}
+  m_Size: {x: 0.30150223, y: 14.332241}
   m_EdgeRadius: 0
 --- !u!114 &830678581 stripped
 MonoBehaviour:
@@ -28386,17 +28256,16 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8360f322c0c684f4e9e93aa717600c6d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::StealthDetector
-  unawareRange: 4
+  unawareRange: 8
   alertedRange: 10
-  fieldOfViewAngle: 90
   obstacleLayers:
     serializedVersion: 2
     m_Bits: 768
   timeToAlert: 0
   drainDelay: 0.5
   timeToCalm: 4
-  suspicionIcon: {fileID: 0}
-  alertIcon: {fileID: 0}
+  mediumThreshold: 0.33
+  highThreshold: 0.66
 --- !u!95 &851437653
 Animator:
   serializedVersion: 7
@@ -28567,7 +28436,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4aa2272a51f01f648aaefce28dce9df8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::EnemyShield
-  shieldCount: 3
+  shieldCount: 2
   shieldIconContainer: {fileID: 4568101}
   iconSpacing: 0.3
 --- !u!114 &875420110
@@ -28630,17 +28499,16 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8360f322c0c684f4e9e93aa717600c6d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::StealthDetector
-  unawareRange: 4
+  unawareRange: 8
   alertedRange: 10
-  fieldOfViewAngle: 90
   obstacleLayers:
     serializedVersion: 2
     m_Bits: 768
   timeToAlert: 0
   drainDelay: 0.5
   timeToCalm: 4
-  suspicionIcon: {fileID: 0}
-  alertIcon: {fileID: 0}
+  mediumThreshold: 0.33
+  highThreshold: 0.66
 --- !u!95 &875420113
 Animator:
   serializedVersion: 7
@@ -28676,6 +28544,97 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::EnemyDeathEffect
   deathParticlePrefab: {fileID: 4713161626215706932, guid: 4fd72346c0c41c442ba884730a730f4d, type: 3}
+--- !u!1 &884294946
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 884294947}
+  - component: {fileID: 884294948}
+  m_Layer: 6
+  m_Name: ShieldIcon1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &884294947
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 884294946}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.42, y: 0.42, z: 0.42}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1511016778}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &884294948
+SpriteRenderer:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 884294946}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 713780959
+  m_SortingLayer: 8
+  m_SortingOrder: 0
+  m_MaskInteraction: 0
+  m_Sprite: {fileID: 21300000, guid: 6a61fe1c681656d4f9cb3146cc805ade, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_SpriteSortPoint: 0
 --- !u!1001 &906432617
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -28880,17 +28839,16 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8360f322c0c684f4e9e93aa717600c6d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::StealthDetector
-  unawareRange: 4
+  unawareRange: 8
   alertedRange: 10
-  fieldOfViewAngle: 90
   obstacleLayers:
     serializedVersion: 2
     m_Bits: 768
   timeToAlert: 0
   drainDelay: 0.5
   timeToCalm: 4
-  suspicionIcon: {fileID: 0}
-  alertIcon: {fileID: 0}
+  mediumThreshold: 0.33
+  highThreshold: 0.66
 --- !u!95 &907381700
 Animator:
   serializedVersion: 7
@@ -29045,117 +29003,6 @@ PrefabInstance:
       insertIndex: -1
       addedObject: {fileID: 194754928}
   m_SourcePrefab: {fileID: 100100000, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
---- !u!1 &941169605 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 7149265674548169254, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-  m_PrefabInstance: {fileID: 507215398}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &941169606
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 941169605}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b7c0a97a28c082d4bace224a35255c76, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: Assembly-CSharp::RangedEnemy
-  enemyData: {fileID: 11400000, guid: 214d017a58ffb2744a6687d0b5800214, type: 2}
-  projectilePrefab: {fileID: 8297447480537988912, guid: a98a98f6aa000b045bb45a9944e3ac9f, type: 3}
-  waypoints: []
-  droppedGoldPrefab: {fileID: 5710133168742629414, guid: bb7a800c10583ec4ca8ff1e6217da669, type: 3}
-  obstacleLayers:
-    serializedVersion: 2
-    m_Bits: 256
-  flashDuration: 0.1
-  flashColor: {r: 1, g: 0, b: 0, a: 1}
---- !u!50 &941169607
-Rigidbody2D:
-  serializedVersion: 5
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 941169605}
-  m_BodyType: 0
-  m_Simulated: 1
-  m_UseFullKinematicContacts: 0
-  m_UseAutoMass: 0
-  m_Mass: 1
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_GravityScale: 1
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_Interpolate: 0
-  m_SleepingMode: 1
-  m_CollisionDetection: 0
-  m_Constraints: 0
---- !u!114 &941169608
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 941169605}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8360f322c0c684f4e9e93aa717600c6d, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: Assembly-CSharp::StealthDetector
-  unawareRange: 4
-  alertedRange: 10
-  fieldOfViewAngle: 90
-  obstacleLayers:
-    serializedVersion: 2
-    m_Bits: 256
-  timeToAlert: 1.5
-  drainDelay: 0.5
-  timeToCalm: 4
-  suspicionIcon: {fileID: 0}
-  alertIcon: {fileID: 0}
---- !u!95 &941169609
-Animator:
-  serializedVersion: 7
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 941169605}
-  m_Enabled: 1
-  m_Avatar: {fileID: 0}
-  m_Controller: {fileID: 0}
-  m_CullingMode: 0
-  m_UpdateMode: 0
-  m_ApplyRootMotion: 0
-  m_LinearVelocityBlending: 0
-  m_StabilizeFeet: 0
-  m_AnimatePhysics: 0
-  m_WarningMessage: 
-  m_HasTransformHierarchy: 1
-  m_AllowConstantClipSamplingOptimization: 1
-  m_KeepAnimatorStateOnDisable: 0
-  m_WriteDefaultValuesOnDisable: 0
---- !u!114 &941169610
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 941169605}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 18dd39af2626ab64597bb0cd8dfc08da, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: Assembly-CSharp::EnemyDeathEffect
-  deathParticlePrefab: {fileID: 4713161626215706932, guid: 4fd72346c0c41c442ba884730a730f4d, type: 3}
 --- !u!1001 &955810287
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -29473,17 +29320,16 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8360f322c0c684f4e9e93aa717600c6d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::StealthDetector
-  unawareRange: 4
+  unawareRange: 8
   alertedRange: 10
-  fieldOfViewAngle: 90
   obstacleLayers:
     serializedVersion: 2
     m_Bits: 768
   timeToAlert: 0
   drainDelay: 0.5
   timeToCalm: 4
-  suspicionIcon: {fileID: 0}
-  alertIcon: {fileID: 0}
+  mediumThreshold: 0.33
+  highThreshold: 0.66
 --- !u!95 &973986715
 Animator:
   serializedVersion: 7
@@ -29589,17 +29435,16 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8360f322c0c684f4e9e93aa717600c6d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::StealthDetector
-  unawareRange: 4
+  unawareRange: 8
   alertedRange: 10
-  fieldOfViewAngle: 90
   obstacleLayers:
     serializedVersion: 2
     m_Bits: 768
   timeToAlert: 0
   drainDelay: 0.5
   timeToCalm: 4
-  suspicionIcon: {fileID: 0}
-  alertIcon: {fileID: 0}
+  mediumThreshold: 0.33
+  highThreshold: 0.66
 --- !u!95 &994669232
 Animator:
   serializedVersion: 7
@@ -29705,17 +29550,16 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8360f322c0c684f4e9e93aa717600c6d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::StealthDetector
-  unawareRange: 4
+  unawareRange: 8
   alertedRange: 10
-  fieldOfViewAngle: 90
   obstacleLayers:
     serializedVersion: 2
     m_Bits: 768
   timeToAlert: 0
   drainDelay: 0.5
   timeToCalm: 4
-  suspicionIcon: {fileID: 0}
-  alertIcon: {fileID: 0}
+  mediumThreshold: 0.33
+  highThreshold: 0.66
 --- !u!95 &1016844539
 Animator:
   serializedVersion: 7
@@ -29927,17 +29771,16 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8360f322c0c684f4e9e93aa717600c6d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::StealthDetector
-  unawareRange: 4
+  unawareRange: 8
   alertedRange: 10
-  fieldOfViewAngle: 90
   obstacleLayers:
     serializedVersion: 2
     m_Bits: 768
   timeToAlert: 0
   drainDelay: 0.5
   timeToCalm: 4
-  suspicionIcon: {fileID: 0}
-  alertIcon: {fileID: 0}
+  mediumThreshold: 0.33
+  highThreshold: 0.66
 --- !u!95 &1041765482
 Animator:
   serializedVersion: 7
@@ -39538,17 +39381,16 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8360f322c0c684f4e9e93aa717600c6d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::StealthDetector
-  unawareRange: 4
+  unawareRange: 8
   alertedRange: 10
-  fieldOfViewAngle: 90
   obstacleLayers:
     serializedVersion: 2
     m_Bits: 768
   timeToAlert: 0
   drainDelay: 0.5
   timeToCalm: 4
-  suspicionIcon: {fileID: 0}
-  alertIcon: {fileID: 0}
+  mediumThreshold: 0.33
+  highThreshold: 0.66
 --- !u!95 &1097898679
 Animator:
   serializedVersion: 7
@@ -39584,6 +39426,67 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::EnemyDeathEffect
   deathParticlePrefab: {fileID: 4713161626215706932, guid: 4fd72346c0c41c442ba884730a730f4d, type: 3}
+--- !u!1001 &1102370900
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 911929358177466543, guid: d1fce84f2ce091744b6b20dea7dffd67, type: 3}
+      propertyPath: m_Name
+      value: StrongEnemy (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3360201154032765571, guid: d1fce84f2ce091744b6b20dea7dffd67, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 4.8
+      objectReference: {fileID: 0}
+    - target: {fileID: 3360201154032765571, guid: d1fce84f2ce091744b6b20dea7dffd67, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 28.05
+      objectReference: {fileID: 0}
+    - target: {fileID: 3360201154032765571, guid: d1fce84f2ce091744b6b20dea7dffd67, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3360201154032765571, guid: d1fce84f2ce091744b6b20dea7dffd67, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3360201154032765571, guid: d1fce84f2ce091744b6b20dea7dffd67, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3360201154032765571, guid: d1fce84f2ce091744b6b20dea7dffd67, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3360201154032765571, guid: d1fce84f2ce091744b6b20dea7dffd67, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3360201154032765571, guid: d1fce84f2ce091744b6b20dea7dffd67, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3360201154032765571, guid: d1fce84f2ce091744b6b20dea7dffd67, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3360201154032765571, guid: d1fce84f2ce091744b6b20dea7dffd67, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3828077422619850012, guid: d1fce84f2ce091744b6b20dea7dffd67, type: 3}
+      propertyPath: shieldCount
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d1fce84f2ce091744b6b20dea7dffd67, type: 3}
 --- !u!1 &1106038510
 GameObject:
   m_ObjectHideFlags: 0
@@ -39709,17 +39612,16 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8360f322c0c684f4e9e93aa717600c6d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::StealthDetector
-  unawareRange: 4
+  unawareRange: 8
   alertedRange: 10
-  fieldOfViewAngle: 90
   obstacleLayers:
     serializedVersion: 2
     m_Bits: 768
   timeToAlert: 0
   drainDelay: 0.5
   timeToCalm: 4
-  suspicionIcon: {fileID: 0}
-  alertIcon: {fileID: 0}
+  mediumThreshold: 0.33
+  highThreshold: 0.66
 --- !u!95 &1120750546
 Animator:
   serializedVersion: 7
@@ -39825,17 +39727,16 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8360f322c0c684f4e9e93aa717600c6d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::StealthDetector
-  unawareRange: 4
+  unawareRange: 8
   alertedRange: 10
-  fieldOfViewAngle: 90
   obstacleLayers:
     serializedVersion: 2
     m_Bits: 768
   timeToAlert: 0
   drainDelay: 0.5
   timeToCalm: 4
-  suspicionIcon: {fileID: 0}
-  alertIcon: {fileID: 0}
+  mediumThreshold: 0.33
+  highThreshold: 0.66
 --- !u!95 &1120821925
 Animator:
   serializedVersion: 7
@@ -40054,17 +39955,16 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8360f322c0c684f4e9e93aa717600c6d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::StealthDetector
-  unawareRange: 4
+  unawareRange: 8
   alertedRange: 10
-  fieldOfViewAngle: 90
   obstacleLayers:
     serializedVersion: 2
     m_Bits: 768
   timeToAlert: 0
   drainDelay: 0.5
   timeToCalm: 4
-  suspicionIcon: {fileID: 0}
-  alertIcon: {fileID: 0}
+  mediumThreshold: 0.33
+  highThreshold: 0.66
 --- !u!95 &1124520814
 Animator:
   serializedVersion: 7
@@ -40170,17 +40070,16 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8360f322c0c684f4e9e93aa717600c6d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::StealthDetector
-  unawareRange: 4
+  unawareRange: 8
   alertedRange: 10
-  fieldOfViewAngle: 90
   obstacleLayers:
     serializedVersion: 2
     m_Bits: 768
   timeToAlert: 0
   drainDelay: 0.5
   timeToCalm: 4
-  suspicionIcon: {fileID: 0}
-  alertIcon: {fileID: 0}
+  mediumThreshold: 0.33
+  highThreshold: 0.66
 --- !u!95 &1141943964
 Animator:
   serializedVersion: 7
@@ -40318,17 +40217,16 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8360f322c0c684f4e9e93aa717600c6d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::StealthDetector
-  unawareRange: 4
+  unawareRange: 8
   alertedRange: 10
-  fieldOfViewAngle: 90
   obstacleLayers:
     serializedVersion: 2
     m_Bits: 768
   timeToAlert: 0
   drainDelay: 0.5
   timeToCalm: 4
-  suspicionIcon: {fileID: 0}
-  alertIcon: {fileID: 0}
+  mediumThreshold: 0.33
+  highThreshold: 0.66
 --- !u!95 &1163780928
 Animator:
   serializedVersion: 7
@@ -40552,6 +40450,23 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!224 &1191076668 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 1743562317605919916, guid: 737607d88ee454ad69f1b4b9214c7805, type: 3}
+  m_PrefabInstance: {fileID: 3450776239777152415}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1191076675
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 395068173}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5efc57b269f6a11448723e4b460ce55f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: GameScripts::PersistentUI
 --- !u!1001 &1197975374
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -40697,6 +40612,143 @@ Transform:
   - {fileID: 695242022}
   m_Father: {fileID: 527006456}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1199059795
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1199059798}
+  - component: {fileID: 1199059797}
+  - component: {fileID: 1199059796}
+  m_Layer: 5
+  m_Name: RedPacketCountText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1199059796
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1199059795}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 0/6
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 70a81763098886148b3ad1285615965b, type: 2}
+  m_sharedMaterial: {fileID: 829339057539629669, guid: 70a81763098886148b3ad1285615965b, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4278190080
+  m_fontColor: {r: 0, g: 0, b: 0, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 60
+  m_fontSizeBase: 60
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 1024
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: -409.98035, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1199059797
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1199059795}
+  m_CullTransparentMesh: 1
+--- !u!224 &1199059798
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1199059795}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1574335320}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -112, y: -238}
+  m_SizeDelta: {x: 200, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &1211388704
 GameObject:
   m_ObjectHideFlags: 0
@@ -40798,17 +40850,16 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8360f322c0c684f4e9e93aa717600c6d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::StealthDetector
-  unawareRange: 4
+  unawareRange: 8
   alertedRange: 10
-  fieldOfViewAngle: 90
   obstacleLayers:
     serializedVersion: 2
     m_Bits: 768
   timeToAlert: 0
   drainDelay: 0.5
   timeToCalm: 4
-  suspicionIcon: {fileID: 0}
-  alertIcon: {fileID: 0}
+  mediumThreshold: 0.33
+  highThreshold: 0.66
 --- !u!95 &1252790084
 Animator:
   serializedVersion: 7
@@ -40914,17 +40965,16 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8360f322c0c684f4e9e93aa717600c6d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::StealthDetector
-  unawareRange: 4
+  unawareRange: 8
   alertedRange: 10
-  fieldOfViewAngle: 90
   obstacleLayers:
     serializedVersion: 2
     m_Bits: 768
   timeToAlert: 0
   drainDelay: 0.5
   timeToCalm: 4
-  suspicionIcon: {fileID: 0}
-  alertIcon: {fileID: 0}
+  mediumThreshold: 0.33
+  highThreshold: 0.66
 --- !u!95 &1265292852
 Animator:
   serializedVersion: 7
@@ -41030,17 +41080,16 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8360f322c0c684f4e9e93aa717600c6d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::StealthDetector
-  unawareRange: 4
+  unawareRange: 8
   alertedRange: 10
-  fieldOfViewAngle: 90
   obstacleLayers:
     serializedVersion: 2
     m_Bits: 768
   timeToAlert: 0
   drainDelay: 0.5
   timeToCalm: 4
-  suspicionIcon: {fileID: 0}
-  alertIcon: {fileID: 0}
+  mediumThreshold: 0.33
+  highThreshold: 0.66
 --- !u!95 &1291477325
 Animator:
   serializedVersion: 7
@@ -41149,6 +41198,8 @@ MonoBehaviour:
   npcName: Village Elder
   faceSprite: {fileID: -7527145504033472756, guid: a7b9de86dd332fc4eb204ef08c7d734e, type: 3}
   interactionIcon: {fileID: 1024845206}
+  exclamationSprite: {fileID: 0}
+  exclamationOffset: {x: 0, y: 1.5, z: 0}
   dialoguePanel: {fileID: 841510794}
   dialogueText: {fileID: 830678581}
   nameText: {fileID: 6439881}
@@ -41424,6 +41475,97 @@ PrefabInstance:
       insertIndex: -1
       addedObject: {fileID: 287278378}
   m_SourcePrefab: {fileID: 100100000, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
+--- !u!1 &1315006352
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1315006353}
+  - component: {fileID: 1315006355}
+  - component: {fileID: 1315006354}
+  m_Layer: 9
+  m_Name: DoorBlocker1 (9)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1315006353
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1315006352}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 24.65, y: -5.72, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1568821666}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1315006354
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1315006352}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 462fc5d45816be540add5cc5b01b3de4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::DoorBlocker
+--- !u!61 &1315006355
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1315006352}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: 0.5142498, y: 2.5844955}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Size: {x: 0.30150223, y: 7.51215}
+  m_EdgeRadius: 0
 --- !u!1001 &1322472095
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -41678,7 +41820,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4aa2272a51f01f648aaefce28dce9df8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::EnemyShield
-  shieldCount: 3
+  shieldCount: 2
   shieldIconContainer: {fileID: 507038835}
   iconSpacing: 0.3
 --- !u!114 &1367584292
@@ -41741,17 +41883,16 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8360f322c0c684f4e9e93aa717600c6d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::StealthDetector
-  unawareRange: 4
+  unawareRange: 8
   alertedRange: 10
-  fieldOfViewAngle: 90
   obstacleLayers:
     serializedVersion: 2
     m_Bits: 768
   timeToAlert: 0
   drainDelay: 0.5
   timeToCalm: 4
-  suspicionIcon: {fileID: 0}
-  alertIcon: {fileID: 0}
+  mediumThreshold: 0.33
+  highThreshold: 0.66
 --- !u!95 &1367584295
 Animator:
   serializedVersion: 7
@@ -41980,17 +42121,16 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8360f322c0c684f4e9e93aa717600c6d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::StealthDetector
-  unawareRange: 4
+  unawareRange: 8
   alertedRange: 10
-  fieldOfViewAngle: 90
   obstacleLayers:
     serializedVersion: 2
     m_Bits: 768
   timeToAlert: 0
   drainDelay: 0.5
   timeToCalm: 4
-  suspicionIcon: {fileID: 0}
-  alertIcon: {fileID: 0}
+  mediumThreshold: 0.33
+  highThreshold: 0.66
 --- !u!95 &1426006036
 Animator:
   serializedVersion: 7
@@ -42746,17 +42886,16 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8360f322c0c684f4e9e93aa717600c6d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::StealthDetector
-  unawareRange: 4
+  unawareRange: 8
   alertedRange: 10
-  fieldOfViewAngle: 90
   obstacleLayers:
     serializedVersion: 2
     m_Bits: 768
   timeToAlert: 0
   drainDelay: 0.5
   timeToCalm: 4
-  suspicionIcon: {fileID: 0}
-  alertIcon: {fileID: 0}
+  mediumThreshold: 0.33
+  highThreshold: 0.66
 --- !u!95 &1484125942
 Animator:
   serializedVersion: 7
@@ -42792,119 +42931,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::EnemyDeathEffect
   deathParticlePrefab: {fileID: 4713161626215706932, guid: 4fd72346c0c41c442ba884730a730f4d, type: 3}
---- !u!1001 &1485303783
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 2389927335297099617, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: flashColor.b
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2389927335297099617, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: flashColor.g
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2389927335297099617, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: flashColor.r
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2591260189200705611, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 5546671543968653177, guid: ed46feb04f87a3544a05e6e5d539b5cb, type: 3}
-    - target: {fileID: 2591260189200705611, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: m_SortingLayer
-      value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: 2591260189200705611, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: m_SortingLayerID
-      value: 1167505161
-      objectReference: {fileID: 0}
-    - target: {fileID: 6425784204000495687, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: m_Size.x
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6425784204000495687, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: m_Size.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6425784204000495687, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: m_IsTrigger
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6926554811131377722, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 3.83
-      objectReference: {fileID: 0}
-    - target: {fileID: 6926554811131377722, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 32.06
-      objectReference: {fileID: 0}
-    - target: {fileID: 6926554811131377722, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6926554811131377722, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6926554811131377722, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6926554811131377722, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6926554811131377722, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6926554811131377722, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6926554811131377722, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6926554811131377722, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7149265674548169254, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: m_Name
-      value: DummyEnemy (3)
-      objectReference: {fileID: 0}
-    - target: {fileID: 7149265674548169254, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: m_IsActive
-      value: 1
-      objectReference: {fileID: 0}
-    m_RemovedComponents:
-    - {fileID: 2389927335297099617, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 7149265674548169254, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 1602626555}
-    - targetCorrespondingSourceObject: {fileID: 7149265674548169254, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 1602626554}
-    - targetCorrespondingSourceObject: {fileID: 7149265674548169254, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 1602626553}
-    - targetCorrespondingSourceObject: {fileID: 7149265674548169254, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 1602626552}
-    - targetCorrespondingSourceObject: {fileID: 7149265674548169254, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 1602626551}
-  m_SourcePrefab: {fileID: 100100000, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
 --- !u!1 &1485742815
 GameObject:
   m_ObjectHideFlags: 0
@@ -43222,122 +43248,180 @@ PrefabInstance:
       insertIndex: -1
       addedObject: {fileID: 1016844536}
   m_SourcePrefab: {fileID: 100100000, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
+--- !u!1 &1511016777
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1511016778}
+  m_Layer: 6
+  m_Name: ShieldIconContainer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1511016778
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1511016777}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.95, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 884294947}
+  m_Father: {fileID: 1484863425138976430}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1512267446 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 2789268708429038856, guid: 737607d88ee454ad69f1b4b9214c7805, type: 3}
   m_PrefabInstance: {fileID: 3450776239777152415}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &1516273701 stripped
+--- !u!1 &1533668964
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 7149265674548169254, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-  m_PrefabInstance: {fileID: 2107015199}
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &1516273702
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1533668965}
+  - component: {fileID: 1533668967}
+  - component: {fileID: 1533668966}
+  m_Layer: 5
+  m_Name: BuffText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1533668965
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1533668964}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.33333334, y: 0.33333334, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 82340206}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 62.202763, y: -21.5}
+  m_SizeDelta: {x: 836.0166, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1533668966
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1516273701}
+  m_GameObject: {fileID: 1533668964}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b7c0a97a28c082d4bace224a35255c76, type: 3}
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
   m_Name: 
-  m_EditorClassIdentifier: Assembly-CSharp::RangedEnemy
-  enemyData: {fileID: 11400000, guid: 214d017a58ffb2744a6687d0b5800214, type: 2}
-  projectilePrefab: {fileID: 8297447480537988912, guid: a98a98f6aa000b045bb45a9944e3ac9f, type: 3}
-  waypoints: []
-  droppedGoldPrefab: {fileID: 5710133168742629414, guid: bb7a800c10583ec4ca8ff1e6217da669, type: 3}
-  obstacleLayers:
-    serializedVersion: 2
-    m_Bits: 256
-  flashDuration: 0.1
-  flashColor: {r: 1, g: 0, b: 0, a: 1}
---- !u!50 &1516273703
-Rigidbody2D:
-  serializedVersion: 5
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1516273701}
-  m_BodyType: 0
-  m_Simulated: 1
-  m_UseFullKinematicContacts: 0
-  m_UseAutoMass: 0
-  m_Mass: 1
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_GravityScale: 1
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
   m_Material: {fileID: 0}
-  m_IncludeLayers:
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: +0 DMG  +0 SPD  +0 HP  +0 SHD
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 70a81763098886148b3ad1285615965b, type: 2}
+  m_sharedMaterial: {fileID: 829339057539629669, guid: 70a81763098886148b3ad1285615965b, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
     serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
     serializedVersion: 2
-    m_Bits: 0
-  m_Interpolate: 0
-  m_SleepingMode: 1
-  m_CollisionDetection: 0
-  m_Constraints: 0
---- !u!114 &1516273704
-MonoBehaviour:
+    rgba: 4294967295
+  m_fontSize: 36
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1533668967
+CanvasRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1516273701}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8360f322c0c684f4e9e93aa717600c6d, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: Assembly-CSharp::StealthDetector
-  unawareRange: 4
-  alertedRange: 10
-  fieldOfViewAngle: 90
-  obstacleLayers:
-    serializedVersion: 2
-    m_Bits: 256
-  timeToAlert: 1.5
-  drainDelay: 0.5
-  timeToCalm: 4
-  suspicionIcon: {fileID: 0}
-  alertIcon: {fileID: 0}
---- !u!95 &1516273705
-Animator:
-  serializedVersion: 7
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1516273701}
-  m_Enabled: 1
-  m_Avatar: {fileID: 0}
-  m_Controller: {fileID: 0}
-  m_CullingMode: 0
-  m_UpdateMode: 0
-  m_ApplyRootMotion: 0
-  m_LinearVelocityBlending: 0
-  m_StabilizeFeet: 0
-  m_AnimatePhysics: 0
-  m_WarningMessage: 
-  m_HasTransformHierarchy: 1
-  m_AllowConstantClipSamplingOptimization: 1
-  m_KeepAnimatorStateOnDisable: 0
-  m_WriteDefaultValuesOnDisable: 0
---- !u!114 &1516273706
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1516273701}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 18dd39af2626ab64597bb0cd8dfc08da, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: Assembly-CSharp::EnemyDeathEffect
-  deathParticlePrefab: {fileID: 4713161626215706932, guid: 4fd72346c0c41c442ba884730a730f4d, type: 3}
+  m_GameObject: {fileID: 1533668964}
+  m_CullTransparentMesh: 1
 --- !u!1 &1543769367
 GameObject:
   m_ObjectHideFlags: 0
@@ -43417,7 +43501,7 @@ BoxCollider2D:
   m_UsedByEffector: 0
   m_CompositeOperation: 0
   m_CompositeOrder: 0
-  m_Offset: {x: 0.5142498, y: -3.2579126}
+  m_Offset: {x: 0.5142498, y: -7.110079}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0, y: 0}
@@ -43427,7 +43511,7 @@ BoxCollider2D:
     drawMode: 0
     adaptiveTiling: 0
   m_AutoTiling: 0
-  m_Size: {x: 0.30150223, y: 12.963251}
+  m_Size: {x: 0.30150223, y: 20.667583}
   m_EdgeRadius: 0
 --- !u!1 &1568821665
 GameObject:
@@ -43462,12 +43546,19 @@ Transform:
   - {fileID: 323807099}
   - {fileID: 1169173385}
   - {fileID: 99835314}
+  - {fileID: 1804596177}
   - {fileID: 331632752}
   - {fileID: 1543769368}
   - {fileID: 198946363}
   - {fileID: 830270421}
+  - {fileID: 1315006353}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!224 &1574335320 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 2786980145057158856, guid: 737607d88ee454ad69f1b4b9214c7805, type: 3}
+  m_PrefabInstance: {fileID: 3450776239777152415}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1578083396
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -43581,117 +43672,6 @@ PrefabInstance:
       insertIndex: -1
       addedObject: {fileID: 1120750543}
   m_SourcePrefab: {fileID: 100100000, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
---- !u!1 &1602626550 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 7149265674548169254, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-  m_PrefabInstance: {fileID: 1485303783}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &1602626551
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1602626550}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b7c0a97a28c082d4bace224a35255c76, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: Assembly-CSharp::RangedEnemy
-  enemyData: {fileID: 11400000, guid: 214d017a58ffb2744a6687d0b5800214, type: 2}
-  projectilePrefab: {fileID: 8297447480537988912, guid: a98a98f6aa000b045bb45a9944e3ac9f, type: 3}
-  waypoints: []
-  droppedGoldPrefab: {fileID: 5710133168742629414, guid: bb7a800c10583ec4ca8ff1e6217da669, type: 3}
-  obstacleLayers:
-    serializedVersion: 2
-    m_Bits: 256
-  flashDuration: 0.1
-  flashColor: {r: 1, g: 0, b: 0, a: 1}
---- !u!50 &1602626552
-Rigidbody2D:
-  serializedVersion: 5
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1602626550}
-  m_BodyType: 0
-  m_Simulated: 1
-  m_UseFullKinematicContacts: 0
-  m_UseAutoMass: 0
-  m_Mass: 1
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_GravityScale: 1
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_Interpolate: 0
-  m_SleepingMode: 1
-  m_CollisionDetection: 0
-  m_Constraints: 0
---- !u!114 &1602626553
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1602626550}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8360f322c0c684f4e9e93aa717600c6d, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: Assembly-CSharp::StealthDetector
-  unawareRange: 4
-  alertedRange: 10
-  fieldOfViewAngle: 90
-  obstacleLayers:
-    serializedVersion: 2
-    m_Bits: 256
-  timeToAlert: 1.5
-  drainDelay: 0.5
-  timeToCalm: 4
-  suspicionIcon: {fileID: 0}
-  alertIcon: {fileID: 0}
---- !u!95 &1602626554
-Animator:
-  serializedVersion: 7
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1602626550}
-  m_Enabled: 1
-  m_Avatar: {fileID: 0}
-  m_Controller: {fileID: 0}
-  m_CullingMode: 0
-  m_UpdateMode: 0
-  m_ApplyRootMotion: 0
-  m_LinearVelocityBlending: 0
-  m_StabilizeFeet: 0
-  m_AnimatePhysics: 0
-  m_WarningMessage: 
-  m_HasTransformHierarchy: 1
-  m_AllowConstantClipSamplingOptimization: 1
-  m_KeepAnimatorStateOnDisable: 0
-  m_WriteDefaultValuesOnDisable: 0
---- !u!114 &1602626555
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1602626550}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 18dd39af2626ab64597bb0cd8dfc08da, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: Assembly-CSharp::EnemyDeathEffect
-  deathParticlePrefab: {fileID: 4713161626215706932, guid: 4fd72346c0c41c442ba884730a730f4d, type: 3}
 --- !u!1 &1647007465
 GameObject:
   m_ObjectHideFlags: 0
@@ -43907,6 +43887,102 @@ PrefabInstance:
       insertIndex: -1
       addedObject: {fileID: 851437649}
   m_SourcePrefab: {fileID: 100100000, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
+--- !u!1 &1685964405
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1685964406}
+  - component: {fileID: 1685964409}
+  - component: {fileID: 1685964408}
+  - component: {fileID: 1685964407}
+  m_Layer: 5
+  m_Name: DamageVignette
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1685964406
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1685964405}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1191076668}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1685964407
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1685964405}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2b291d7ed5c356d4eb162376d51d8a5f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: GameScripts::DamageVignette
+  vignetteImage: {fileID: 1685964408}
+  flashPeakAlpha: 0.5
+  lowHPFlashPeakAlpha: 0.8
+  flashFadeDuration: 0.3
+  hpThreshold: 20
+  pulseSpeed: 3
+  pulseAmplitude: 0.08
+  pulseBaseline: 0.2
+--- !u!114 &1685964408
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1685964405}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 0, b: 0, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1685964409
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1685964405}
+  m_CullTransparentMesh: 1
 --- !u!1 &1691703737
 GameObject:
   m_ObjectHideFlags: 0
@@ -44620,7 +44696,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4aa2272a51f01f648aaefce28dce9df8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::EnemyShield
-  shieldCount: 3
+  shieldCount: 1
   shieldIconContainer: {fileID: 2120457063}
   iconSpacing: 0.3
 --- !u!114 &1794380310
@@ -44683,17 +44759,16 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8360f322c0c684f4e9e93aa717600c6d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::StealthDetector
-  unawareRange: 4
+  unawareRange: 8
   alertedRange: 10
-  fieldOfViewAngle: 90
   obstacleLayers:
     serializedVersion: 2
     m_Bits: 768
   timeToAlert: 0
   drainDelay: 0.5
   timeToCalm: 4
-  suspicionIcon: {fileID: 0}
-  alertIcon: {fileID: 0}
+  mediumThreshold: 0.33
+  highThreshold: 0.66
 --- !u!95 &1794380313
 Animator:
   serializedVersion: 7
@@ -44799,17 +44874,16 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8360f322c0c684f4e9e93aa717600c6d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::StealthDetector
-  unawareRange: 4
+  unawareRange: 8
   alertedRange: 10
-  fieldOfViewAngle: 90
   obstacleLayers:
     serializedVersion: 2
     m_Bits: 768
   timeToAlert: 0
   drainDelay: 0.5
   timeToCalm: 4
-  suspicionIcon: {fileID: 0}
-  alertIcon: {fileID: 0}
+  mediumThreshold: 0.33
+  highThreshold: 0.66
 --- !u!95 &1797193121
 Animator:
   serializedVersion: 7
@@ -44915,17 +44989,16 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8360f322c0c684f4e9e93aa717600c6d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::StealthDetector
-  unawareRange: 4
+  unawareRange: 8
   alertedRange: 10
-  fieldOfViewAngle: 90
   obstacleLayers:
     serializedVersion: 2
     m_Bits: 768
   timeToAlert: 0
   drainDelay: 0.5
   timeToCalm: 4
-  suspicionIcon: {fileID: 0}
-  alertIcon: {fileID: 0}
+  mediumThreshold: 0.33
+  highThreshold: 0.66
 --- !u!95 &1804576016
 Animator:
   serializedVersion: 7
@@ -44961,6 +45034,97 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::EnemyDeathEffect
   deathParticlePrefab: {fileID: 4713161626215706932, guid: 4fd72346c0c41c442ba884730a730f4d, type: 3}
+--- !u!1 &1804596176
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1804596177}
+  - component: {fileID: 1804596179}
+  - component: {fileID: 1804596178}
+  m_Layer: 9
+  m_Name: DoorBlocker1 (8)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1804596177
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1804596176}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 10.4, y: 0.8, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1568821666}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1804596178
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1804596176}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 462fc5d45816be540add5cc5b01b3de4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::DoorBlocker
+--- !u!61 &1804596179
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1804596176}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: -1.2912769, y: 0.38231754}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Size: {x: 13.942417, y: 0.32636452}
+  m_EdgeRadius: 0
 --- !u!1 &1839758511
 GameObject:
   m_ObjectHideFlags: 0
@@ -48389,6 +48553,160 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1852149039
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 911929358177466543, guid: d1fce84f2ce091744b6b20dea7dffd67, type: 3}
+      propertyPath: m_Name
+      value: StrongEnemy (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3360201154032765571, guid: d1fce84f2ce091744b6b20dea7dffd67, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 4.8
+      objectReference: {fileID: 0}
+    - target: {fileID: 3360201154032765571, guid: d1fce84f2ce091744b6b20dea7dffd67, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 34.53
+      objectReference: {fileID: 0}
+    - target: {fileID: 3360201154032765571, guid: d1fce84f2ce091744b6b20dea7dffd67, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3360201154032765571, guid: d1fce84f2ce091744b6b20dea7dffd67, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3360201154032765571, guid: d1fce84f2ce091744b6b20dea7dffd67, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3360201154032765571, guid: d1fce84f2ce091744b6b20dea7dffd67, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3360201154032765571, guid: d1fce84f2ce091744b6b20dea7dffd67, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3360201154032765571, guid: d1fce84f2ce091744b6b20dea7dffd67, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3360201154032765571, guid: d1fce84f2ce091744b6b20dea7dffd67, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3360201154032765571, guid: d1fce84f2ce091744b6b20dea7dffd67, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3828077422619850012, guid: d1fce84f2ce091744b6b20dea7dffd67, type: 3}
+      propertyPath: shieldCount
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d1fce84f2ce091744b6b20dea7dffd67, type: 3}
+--- !u!1 &1855489705
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1855489708}
+  - component: {fileID: 1855489707}
+  - component: {fileID: 1855489706}
+  m_Layer: 0
+  m_Name: TownReplenishZone
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!61 &1855489706
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1855489705}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: -0.3402834, y: 2.646658}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Size: {x: 17.106798, y: 33.137966}
+  m_EdgeRadius: 0
+--- !u!114 &1855489707
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1855489705}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 79b20f48233cc1d42817fbedd0053346, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: GameScripts::ReplenishZone
+  replenishHP: 1
+  replenishShields: 1
+--- !u!4 &1855489708
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1855489705}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: -1.27, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1859492729
 GameObject:
   m_ObjectHideFlags: 0
@@ -48770,6 +49088,8 @@ MonoBehaviour:
   npcName: Merchant
   faceSprite: {fileID: -7527145504033472756, guid: 3c71281c42b3afa48b68ba353e90be29, type: 3}
   interactionIcon: {fileID: 0}
+  exclamationSprite: {fileID: 0}
+  exclamationOffset: {x: 0, y: 1.5, z: 0}
   dialoguePanel: {fileID: 841510794}
   dialogueText: {fileID: 830678581}
   nameText: {fileID: 6439881}
@@ -49062,17 +49382,16 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8360f322c0c684f4e9e93aa717600c6d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::StealthDetector
-  unawareRange: 4
+  unawareRange: 8
   alertedRange: 10
-  fieldOfViewAngle: 90
   obstacleLayers:
     serializedVersion: 2
     m_Bits: 768
   timeToAlert: 0
   drainDelay: 0.5
   timeToCalm: 4
-  suspicionIcon: {fileID: 0}
-  alertIcon: {fileID: 0}
+  mediumThreshold: 0.33
+  highThreshold: 0.66
 --- !u!95 &1947079896
 Animator:
   serializedVersion: 7
@@ -49485,17 +49804,16 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8360f322c0c684f4e9e93aa717600c6d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::StealthDetector
-  unawareRange: 4
+  unawareRange: 8
   alertedRange: 10
-  fieldOfViewAngle: 90
   obstacleLayers:
     serializedVersion: 2
     m_Bits: 768
   timeToAlert: 0
   drainDelay: 0.5
   timeToCalm: 4
-  suspicionIcon: {fileID: 0}
-  alertIcon: {fileID: 0}
+  mediumThreshold: 0.33
+  highThreshold: 0.66
 --- !u!95 &2048984027
 Animator:
   serializedVersion: 7
@@ -49692,17 +50010,16 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8360f322c0c684f4e9e93aa717600c6d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::StealthDetector
-  unawareRange: 4
+  unawareRange: 8
   alertedRange: 10
-  fieldOfViewAngle: 90
   obstacleLayers:
     serializedVersion: 2
     m_Bits: 768
   timeToAlert: 0
   drainDelay: 0.5
   timeToCalm: 4
-  suspicionIcon: {fileID: 0}
-  alertIcon: {fileID: 0}
+  mediumThreshold: 0.33
+  highThreshold: 0.66
 --- !u!95 &2081591787
 Animator:
   serializedVersion: 7
@@ -50147,119 +50464,6 @@ SpriteRenderer:
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1
   m_SpriteSortPoint: 0
---- !u!1001 &2107015199
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 2389927335297099617, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: flashColor.b
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2389927335297099617, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: flashColor.g
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2389927335297099617, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: flashColor.r
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2591260189200705611, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 5546671543968653177, guid: ed46feb04f87a3544a05e6e5d539b5cb, type: 3}
-    - target: {fileID: 2591260189200705611, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: m_SortingLayer
-      value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: 2591260189200705611, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: m_SortingLayerID
-      value: 1167505161
-      objectReference: {fileID: 0}
-    - target: {fileID: 6425784204000495687, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: m_Size.x
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6425784204000495687, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: m_Size.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6425784204000495687, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: m_IsTrigger
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6926554811131377722, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 4.32
-      objectReference: {fileID: 0}
-    - target: {fileID: 6926554811131377722, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 28.47
-      objectReference: {fileID: 0}
-    - target: {fileID: 6926554811131377722, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6926554811131377722, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6926554811131377722, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6926554811131377722, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6926554811131377722, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6926554811131377722, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6926554811131377722, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6926554811131377722, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7149265674548169254, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: m_Name
-      value: DummyEnemy (1)
-      objectReference: {fileID: 0}
-    - target: {fileID: 7149265674548169254, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      propertyPath: m_IsActive
-      value: 1
-      objectReference: {fileID: 0}
-    m_RemovedComponents:
-    - {fileID: 2389927335297099617, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 7149265674548169254, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 1516273706}
-    - targetCorrespondingSourceObject: {fileID: 7149265674548169254, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 1516273705}
-    - targetCorrespondingSourceObject: {fileID: 7149265674548169254, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 1516273704}
-    - targetCorrespondingSourceObject: {fileID: 7149265674548169254, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 1516273703}
-    - targetCorrespondingSourceObject: {fileID: 7149265674548169254, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 1516273702}
-  m_SourcePrefab: {fileID: 100100000, guid: 3d1272537c8a84bf3979ff3dbb2592fd, type: 3}
 --- !u!1 &2110042766
 GameObject:
   m_ObjectHideFlags: 0
@@ -50566,12 +50770,75 @@ Transform:
   m_Children: []
   m_Father: {fileID: 1106038512}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2145322301
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2145322303}
+  - component: {fileID: 2145322302}
+  m_Layer: 0
+  m_Name: RedPacketTracker
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &2145322302
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2145322301}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7241eba5b94b7bf478523584a2a65641, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: GameScripts::RedPacketTracker
+  dojoQuests:
+  - {fileID: 11400000, guid: 0d79782ed656b054f8357c3bb175df39, type: 2}
+  mapNames:
+  - Humble Village
+  - Snowy Town
+  - Fishing Port
+  - Merchant Town
+  - Abandoned Outpost
+  - Royal Castle
+  mapSceneNames:
+  - Humble Village
+  - Snowy Town
+  - Fishing Port
+  - Merchant Town
+  - Abandoned Outpost
+  - Royal Castle
+  onRedPacketCollected:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!4 &2145322303
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2145322301}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -5.00371, y: -12.56026, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &281105377575604956 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 6520786891205671775, guid: da0c0c8dc895e94498aa675def287ec6, type: 3}
   m_PrefabInstance: {fileID: 3334623305622404976}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
+  m_GameObject: {fileID: 671340672}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: b8b2aa194214f0b48b12708ff7af634c, type: 3}
@@ -50582,63 +50849,6 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 1608024051375494111, guid: da0c0c8dc895e94498aa675def287ec6, type: 3}
   m_PrefabInstance: {fileID: 3334623305622404976}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &2077056024219647411
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 473441239725259464, guid: 4fbcaad1bf7a0f24988a97e45446c8b5, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -1.1220056
-      objectReference: {fileID: 0}
-    - target: {fileID: 473441239725259464, guid: 4fbcaad1bf7a0f24988a97e45446c8b5, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 28.548807
-      objectReference: {fileID: 0}
-    - target: {fileID: 473441239725259464, guid: 4fbcaad1bf7a0f24988a97e45446c8b5, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 473441239725259464, guid: 4fbcaad1bf7a0f24988a97e45446c8b5, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 473441239725259464, guid: 4fbcaad1bf7a0f24988a97e45446c8b5, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 473441239725259464, guid: 4fbcaad1bf7a0f24988a97e45446c8b5, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 473441239725259464, guid: 4fbcaad1bf7a0f24988a97e45446c8b5, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 473441239725259464, guid: 4fbcaad1bf7a0f24988a97e45446c8b5, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 473441239725259464, guid: 4fbcaad1bf7a0f24988a97e45446c8b5, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 473441239725259464, guid: 4fbcaad1bf7a0f24988a97e45446c8b5, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3096025957761224703, guid: 4fbcaad1bf7a0f24988a97e45446c8b5, type: 3}
-      propertyPath: m_Name
-      value: DummyEnemy
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 4fbcaad1bf7a0f24988a97e45446c8b5, type: 3}
 --- !u!1001 &3334623305622404976
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -50697,8 +50907,14 @@ PrefabInstance:
       objectReference: {fileID: 1106038511}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 1608024051375494111, guid: da0c0c8dc895e94498aa675def287ec6, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1511016778}
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 1405046755992410545, guid: da0c0c8dc895e94498aa675def287ec6, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 3995090908665547203}
   m_SourcePrefab: {fileID: 100100000, guid: da0c0c8dc895e94498aa675def287ec6, type: 3}
 --- !u!1001 &3450776239777152415
 PrefabInstance:
@@ -50712,8 +50928,60 @@ PrefabInstance:
       propertyPath: m_Name
       value: UI
       objectReference: {fileID: 0}
+    - target: {fileID: 692184412789498475, guid: 737607d88ee454ad69f1b4b9214c7805, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 692184412789498475, guid: 737607d88ee454ad69f1b4b9214c7805, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 692184412789498475, guid: 737607d88ee454ad69f1b4b9214c7805, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 692184412789498475, guid: 737607d88ee454ad69f1b4b9214c7805, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1230515397029868622, guid: 737607d88ee454ad69f1b4b9214c7805, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1230515397029868622, guid: 737607d88ee454ad69f1b4b9214c7805, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1230515397029868622, guid: 737607d88ee454ad69f1b4b9214c7805, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1230515397029868622, guid: 737607d88ee454ad69f1b4b9214c7805, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1230515397029868622, guid: 737607d88ee454ad69f1b4b9214c7805, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1230515397029868622, guid: 737607d88ee454ad69f1b4b9214c7805, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 1477063164712567850, guid: 737607d88ee454ad69f1b4b9214c7805, type: 3}
       propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1579519961813473933, guid: 737607d88ee454ad69f1b4b9214c7805, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1579519961813473933, guid: 737607d88ee454ad69f1b4b9214c7805, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1579519961813473933, guid: 737607d88ee454ad69f1b4b9214c7805, type: 3}
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1726553917522113132, guid: 737607d88ee454ad69f1b4b9214c7805, type: 3}
@@ -50804,6 +51072,58 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 4031265057353672104, guid: 737607d88ee454ad69f1b4b9214c7805, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4031265057353672104, guid: 737607d88ee454ad69f1b4b9214c7805, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4031265057353672104, guid: 737607d88ee454ad69f1b4b9214c7805, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4031265057353672104, guid: 737607d88ee454ad69f1b4b9214c7805, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4031265057353672104, guid: 737607d88ee454ad69f1b4b9214c7805, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4031265057353672104, guid: 737607d88ee454ad69f1b4b9214c7805, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4368391711352460986, guid: 737607d88ee454ad69f1b4b9214c7805, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4368391711352460986, guid: 737607d88ee454ad69f1b4b9214c7805, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4368391711352460986, guid: 737607d88ee454ad69f1b4b9214c7805, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4368391711352460986, guid: 737607d88ee454ad69f1b4b9214c7805, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4368391711352460986, guid: 737607d88ee454ad69f1b4b9214c7805, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4368391711352460986, guid: 737607d88ee454ad69f1b4b9214c7805, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4498125033247755228, guid: 737607d88ee454ad69f1b4b9214c7805, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0.00094289595
+      objectReference: {fileID: 0}
     - target: {fileID: 4720751111728809296, guid: 737607d88ee454ad69f1b4b9214c7805, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -50816,10 +51136,94 @@ PrefabInstance:
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 5153646933746485831, guid: 737607d88ee454ad69f1b4b9214c7805, type: 3}
+      propertyPath: redPacketCountText
+      value: 
+      objectReference: {fileID: 1199059796}
+    - target: {fileID: 5153646933746485831, guid: 737607d88ee454ad69f1b4b9214c7805, type: 3}
+      propertyPath: redPacketLabelText
+      value: 
+      objectReference: {fileID: 205948712}
+    - target: {fileID: 5260941136550621308, guid: 737607d88ee454ad69f1b4b9214c7805, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5260941136550621308, guid: 737607d88ee454ad69f1b4b9214c7805, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5537682447535833248, guid: 737607d88ee454ad69f1b4b9214c7805, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5537682447535833248, guid: 737607d88ee454ad69f1b4b9214c7805, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5725514882738836432, guid: 737607d88ee454ad69f1b4b9214c7805, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5725514882738836432, guid: 737607d88ee454ad69f1b4b9214c7805, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5725514882738836432, guid: 737607d88ee454ad69f1b4b9214c7805, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5725514882738836432, guid: 737607d88ee454ad69f1b4b9214c7805, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5725514882738836432, guid: 737607d88ee454ad69f1b4b9214c7805, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5725514882738836432, guid: 737607d88ee454ad69f1b4b9214c7805, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6007817696370583099, guid: 737607d88ee454ad69f1b4b9214c7805, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6007817696370583099, guid: 737607d88ee454ad69f1b4b9214c7805, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6007817696370583099, guid: 737607d88ee454ad69f1b4b9214c7805, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6007817696370583099, guid: 737607d88ee454ad69f1b4b9214c7805, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6007817696370583099, guid: 737607d88ee454ad69f1b4b9214c7805, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6007817696370583099, guid: 737607d88ee454ad69f1b4b9214c7805, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 6585861549565920017, guid: 737607d88ee454ad69f1b4b9214c7805, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 6587249881627935154, guid: 737607d88ee454ad69f1b4b9214c7805, type: 3}
+      propertyPath: startingSkills.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6587249881627935154, guid: 737607d88ee454ad69f1b4b9214c7805, type: 3}
+      propertyPath: 'startingSkills.Array.data[0]'
+      value: 
+      objectReference: {fileID: 11400000, guid: 6528a7ba19e14364e91b350627d2478e, type: 2}
+    - target: {fileID: 7544556661477979074, guid: 737607d88ee454ad69f1b4b9214c7805, type: 3}
+      propertyPath: buffText
+      value: 
+      objectReference: {fileID: 1533668966}
     - target: {fileID: 7544556661477979074, guid: 737607d88ee454ad69f1b4b9214c7805, type: 3}
       propertyPath: greedMeter
       value: 
@@ -50838,20 +51242,52 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 1743562317605919916, guid: 737607d88ee454ad69f1b4b9214c7805, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1685964406}
+    - targetCorrespondingSourceObject: {fileID: 324305415555439952, guid: 737607d88ee454ad69f1b4b9214c7805, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1533668965}
+    - targetCorrespondingSourceObject: {fileID: 2786980145057158856, guid: 737607d88ee454ad69f1b4b9214c7805, type: 3}
+      insertIndex: 4
+      addedObject: {fileID: 205948714}
+    - targetCorrespondingSourceObject: {fileID: 2786980145057158856, guid: 737607d88ee454ad69f1b4b9214c7805, type: 3}
+      insertIndex: 6
+      addedObject: {fileID: 1199059798}
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 432460049451275601, guid: 737607d88ee454ad69f1b4b9214c7805, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1191076675}
   m_SourcePrefab: {fileID: 100100000, guid: 737607d88ee454ad69f1b4b9214c7805, type: 3}
 --- !u!114 &3995090908665547192 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 5365174095525522066, guid: da0c0c8dc895e94498aa675def287ec6, type: 3}
   m_PrefabInstance: {fileID: 3334623305622404976}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
+  m_GameObject: {fileID: 671340672}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 896e7c2550ef5a7479eb81fc6951f7e8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::GreedMeter
+--- !u!114 &3995090908665547203
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 671340672}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9a48ba7539c482140904e8d591f324a3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: GameScripts::PlayerShield
+  OnShieldChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  shieldIconContainer: {fileID: 1511016777}
+  iconSpacing: 0.3
 --- !u!1001 &4778402135211694387
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -50866,11 +51302,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3360201154032765571, guid: d1fce84f2ce091744b6b20dea7dffd67, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 5
+      value: -4.67
       objectReference: {fileID: 0}
     - target: {fileID: 3360201154032765571, guid: d1fce84f2ce091744b6b20dea7dffd67, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 22.06
+      value: 28.05
       objectReference: {fileID: 0}
     - target: {fileID: 3360201154032765571, guid: d1fce84f2ce091744b6b20dea7dffd67, type: 3}
       propertyPath: m_LocalPosition.z
@@ -50904,6 +51340,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 3828077422619850012, guid: d1fce84f2ce091744b6b20dea7dffd67, type: 3}
+      propertyPath: shieldCount
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -50926,12 +51366,10 @@ SceneRoots:
   - {fileID: 334681394}
   - {fileID: 1882317858}
   - {fileID: 160614929}
-  - {fileID: 2077056024219647411}
-  - {fileID: 2107015199}
-  - {fileID: 628957442}
-  - {fileID: 1485303783}
-  - {fileID: 507215398}
   - {fileID: 4778402135211694387}
+  - {fileID: 1102370900}
+  - {fileID: 1852149039}
+  - {fileID: 290751110}
   - {fileID: 1859492731}
   - {fileID: 2036375}
   - {fileID: 1106038512}
@@ -50941,3 +51379,5 @@ SceneRoots:
   - {fileID: 190350739}
   - {fileID: 1849850389}
   - {fileID: 1568821666}
+  - {fileID: 2145322303}
+  - {fileID: 1855489708}

--- a/Journey To The West/Assets/Scripts/Map/ScreenFader.cs
+++ b/Journey To The West/Assets/Scripts/Map/ScreenFader.cs
@@ -11,11 +11,17 @@ public class ScreenFader : MonoBehaviour
     {
         if (Instance != null && Instance != this)
         {
-            Destroy(Instance.gameObject);
+            Destroy(gameObject);
+            return;
         }
 
         Instance = this;
-        DontDestroyOnLoad(gameObject);
+    }
+
+    private void OnDestroy()
+    {
+        if (Instance == this)
+            Instance = null;
     }
 
     async Task Fade(float personTransparency)

--- a/Journey To The West/Assets/Scripts/NPC/DojoMasterNPC.cs
+++ b/Journey To The West/Assets/Scripts/NPC/DojoMasterNPC.cs
@@ -16,6 +16,24 @@ public class DojoMasterNPC : NPCBase
     private bool questStarted;
     private bool hasGivenPackage;
 
+    private void Start()
+    {
+        // Restore state from QuestManager so the NPC stays disabled after scene re-entry
+        if (questToStart != null && QuestManager.Instance != null)
+        {
+            if (QuestManager.Instance.IsQuestCompleted(questToStart))
+            {
+                questStarted = true;
+                hasGivenPackage = true;
+                ShowInteractionIcon(false);
+            }
+            else if (QuestManager.Instance.IsQuestActive(questToStart))
+            {
+                questStarted = true;
+            }
+        }
+    }
+
     public override void Interact(GameObject player)
     {
         if (playerInventory == null)

--- a/Journey To The West/Assets/Scripts/Player/GreedMeter.cs
+++ b/Journey To The West/Assets/Scripts/Player/GreedMeter.cs
@@ -10,6 +10,14 @@ public class GreedMeter : MonoBehaviour
     public UnityEvent<int> OnGoldChanged;
     public UnityEvent<GreedTier> OnTierChanged;
 
+    private void Awake()
+    {
+        // Silently sync tier from serialized gold so other components
+        // read the correct value in their Start(), without firing events
+        // that cause cascading init issues.
+        currentTier = GreedMeterLogic.CalculateTier(currentGold);
+    }
+
     public void AddGold(int amount)
     {
         if (amount <= 0) return;

--- a/Journey To The West/Assets/Scripts/Player/PlayerCombat.cs
+++ b/Journey To The West/Assets/Scripts/Player/PlayerCombat.cs
@@ -59,13 +59,25 @@ public class PlayerCombat : MonoBehaviour, IDamageable
         playerController = GetComponent<PlayerController>();
         animator = GetComponent<Animator>();
         spriteRenderer = GetComponent<SpriteRenderer>();
-        effectiveMaxHP = baseMaxHP * maxHPModifier;
+        RecalculateMaxHP();
         currentHP = effectiveMaxHP;
+    }
+
+    private void OnEnable()
+    {
+        if (greedMeter != null)
+            greedMeter.OnTierChanged.AddListener(OnGreedTierChanged);
+    }
+
+    private void OnDisable()
+    {
+        if (greedMeter != null)
+            greedMeter.OnTierChanged.RemoveListener(OnGreedTierChanged);
     }
 
     private void Start()
     {
-        effectiveMaxHP = baseMaxHP * maxHPModifier;
+        RecalculateMaxHP();
         currentHP = effectiveMaxHP;
         lastCheckpoint = transform.position;
         HustleStyleManager.Instance?.RefreshStyleEffects();
@@ -75,6 +87,25 @@ public class PlayerCombat : MonoBehaviour, IDamageable
         equippedSkill = null;
         if (dashAttackHandler != null)
             dashAttackHandler.SetReticleActive(false);
+    }
+
+    private void OnGreedTierChanged(GreedTier tier)
+    {
+        float previousMax = effectiveMaxHP;
+        RecalculateMaxHP();
+        // Add the HP difference so the player gains the bonus immediately
+        float hpGain = effectiveMaxHP - previousMax;
+        if (hpGain > 0f)
+            currentHP = Mathf.Min(currentHP + hpGain, effectiveMaxHP);
+        else
+            currentHP = Mathf.Min(currentHP, effectiveMaxHP);
+        OnHPChanged?.Invoke(currentHP, effectiveMaxHP);
+    }
+
+    private void RecalculateMaxHP()
+    {
+        float bonusHP = greedMeter != null ? greedMeter.GetBonusHP() : 0f;
+        effectiveMaxHP = (baseMaxHP + bonusHP) * maxHPModifier;
     }
 
     private void Update()
@@ -306,7 +337,7 @@ public class PlayerCombat : MonoBehaviour, IDamageable
         float healthPercent = previousMaxHP > 0f ? currentHP / previousMaxHP : 1f;
 
         maxHPModifier = sanitizedModifier;
-        effectiveMaxHP = baseMaxHP * maxHPModifier;
+        RecalculateMaxHP();
         currentHP = Mathf.Clamp(effectiveMaxHP * healthPercent, 0f, effectiveMaxHP);
 
         OnHPChanged?.Invoke(currentHP, effectiveMaxHP);

--- a/Journey To The West/Assets/Scripts/Player/PlayerShield.cs
+++ b/Journey To The West/Assets/Scripts/Player/PlayerShield.cs
@@ -18,6 +18,9 @@ public class PlayerShield : MonoBehaviour
     private void Awake()
     {
         greedMeter = GetComponent<GreedMeter>();
+        // Hide shield icons until a greed tier grants them
+        if (shieldIconContainer != null)
+            shieldIconContainer.SetActive(false);
     }
 
     private void OnEnable()
@@ -34,19 +37,25 @@ public class PlayerShield : MonoBehaviour
 
     private void Start()
     {
-        SpawnIcons(GetMaxShields());
+        // Sync to whatever the current tier already is (e.g. after scene load
+        // with serialized gold or DontDestroyOnLoad carry-over).
+        int max = GetMaxShields();
+        if (max > 0)
+        {
+            currentShields = max;
+            SpawnIcons(max);
+        }
     }
 
     public bool HasShields() => currentShields > 0;
 
     /// <summary>
     /// Tries to absorb a hit. Returns true if a shield absorbed it.
-    /// Identical to EnemyShield.TryAbsorbHit().
     /// </summary>
     public bool TryAbsorbHit()
     {
         if (currentShields <= 0) return false;
-        if (Time.time < shieldCooldownUntil) return true; // still protected, don't consume another
+        if (Time.time < shieldCooldownUntil) return true;
 
         currentShields--;
         shieldCooldownUntil = Time.time + 0.3f;
@@ -76,12 +85,10 @@ public class PlayerShield : MonoBehaviour
     }
 
     /// <summary>
-    /// Same approach as EnemyShield.SpawnIcons():
-    /// uses first child of container as template, duplicates as needed.
+    /// Uses first child of container as template, duplicates as needed.
     /// </summary>
     private void SpawnIcons(int count)
     {
-        Debug.Log($"[PlayerShield] SpawnIcons called. count={count}, container={shieldIconContainer != null}, children={shieldIconContainer?.transform.childCount}");
         if (shieldIconContainer == null) return;
 
         // Destroy all children except the first (template)
@@ -113,19 +120,12 @@ public class PlayerShield : MonoBehaviour
 
     private void UpdateShieldDisplay()
     {
-        if (shieldIcons == null)
-        {
-            Debug.Log("[PlayerShield] UpdateShieldDisplay: shieldIcons is NULL");
-            return;
-        }
+        if (shieldIcons == null) return;
 
-        Debug.Log($"[PlayerShield] UpdateShieldDisplay: currentShields={currentShields}, icons={shieldIcons.Length}");
         for (int i = 0; i < shieldIcons.Length; i++)
         {
-            bool shouldBeActive = i < currentShields;
-            Debug.Log($"[PlayerShield]   icon[{i}] null={shieldIcons[i] == null}, setActive={shouldBeActive}");
             if (shieldIcons[i] != null)
-                shieldIcons[i].SetActive(shouldBeActive);
+                shieldIcons[i].SetActive(i < currentShields);
         }
 
         // Center visible icons horizontally

--- a/Journey To The West/Assets/Scripts/Player/RedPacketTracker.cs
+++ b/Journey To The West/Assets/Scripts/Player/RedPacketTracker.cs
@@ -62,7 +62,7 @@ public class RedPacketTracker : MonoBehaviour
     {
         if (Array.IndexOf(dojoQuests, quest) >= 0)
         {
-            Collect(SceneManager.GetActiveScene().name);
+            Collect("quest:" + quest.questName);
         }
     }
 

--- a/Journey To The West/Assets/Scripts/UI/DamageVignette.cs
+++ b/Journey To The West/Assets/Scripts/UI/DamageVignette.cs
@@ -27,15 +27,21 @@ public class DamageVignette : MonoBehaviour
     {
         if (Instance != null && Instance != this)
         {
-            Destroy(Instance.gameObject);
+            Destroy(gameObject);
+            return;
         }
 
         Instance = this;
-        DontDestroyOnLoad(gameObject);
 
         baseColor = vignetteImage.color;
         vignetteImage.raycastTarget = false;
         SetAlpha(0f);
+    }
+
+    private void OnDestroy()
+    {
+        if (Instance == this)
+            Instance = null;
     }
 
     private void OnEnable()

--- a/Journey To The West/Assets/Scripts/UI/PersistentUI.cs
+++ b/Journey To The West/Assets/Scripts/UI/PersistentUI.cs
@@ -1,0 +1,25 @@
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+public class PersistentUI : MonoBehaviour
+{
+    public static PersistentUI Instance { get; private set; }
+
+    private void Awake()
+    {
+        if (Instance != null && Instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+
+        Instance = this;
+        DontDestroyOnLoad(gameObject);
+    }
+
+    private void OnDestroy()
+    {
+        if (Instance == this)
+            Instance = null;
+    }
+}

--- a/Journey To The West/Assets/Scripts/UI/PersistentUI.cs.meta
+++ b/Journey To The West/Assets/Scripts/UI/PersistentUI.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5efc57b269f6a11448723e4b460ce55f


### PR DESCRIPTION

- PlayerShield: hide icons at start, update on greed tier change, clean up debug logs
- PlayerCombat: subscribe to OnTierChanged to update max HP with greed bonus
- GreedMeter: silently init tier from serialized gold in Awake (no event cascade)
- DojoMasterNPC: restore quest/dialogue state from QuestManager on Start
- RedPacketTracker: use quest name as collection key to avoid scene-name collision (1/6→2/6 bug)
- PersistentUI: new singleton to DontDestroyOnLoad the entire UI canvas
- DamageVignette/ScreenFader: remove broken child DontDestroyOnLoad, use destroy-self pattern
- Main.unity: fix SceneTeleporter targetSpawnId from "default" to "from_town_a"